### PR TITLE
Fix formal Release installation in 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Self-hosted OpenAI Codex Web UI and Android client bridge.
 ## 快速入口
 
 - 最新 Release: [github.com/Qjzn/CX-Codex/releases/latest](https://github.com/Qjzn/CX-Codex/releases/latest)
+- 2.5.1 发布说明: [docs/release-notes-2.5.1.zh-CN.md](./docs/release-notes-2.5.1.zh-CN.md)
 - 2.5.0 发布说明: [docs/release-notes-2.5.0.zh-CN.md](./docs/release-notes-2.5.0.zh-CN.md)
 - 2.4.1 发布说明: [docs/release-notes-2.4.1.zh-CN.md](./docs/release-notes-2.4.1.zh-CN.md)
 - 2.4.0 发布说明: [docs/release-notes-2.4.0.zh-CN.md](./docs/release-notes-2.4.0.zh-CN.md)

--- a/docs/changelog.zh-CN.md
+++ b/docs/changelog.zh-CN.md
@@ -2,6 +2,11 @@
 
 ## 未发布
 
+## 2.5.1 - 2026-07-25
+
+- 修复 2.5.0 Release zip 遗漏 Vite 的 `local-preview.html` 入口，导致默认 bootstrap 已通过 SHA-256 校验和依赖安装后仍在构建阶段失败的问题；Release package smoke 现在强制检查两个根 HTML 入口。
+- JSON 安装模式在 npm 真正失败时会继续输出原始 stderr 诊断，同时仍只依据 npm 退出码判断成功或失败，避免只看到笼统的 `npm run build failed`。
+
 ## 2.5.0 - 2026-07-25
 
 - Windows 安装/卸载开始使用版本化产品契约：归档新增 `release-capabilities.json`，bootstrap 在使用 `RemoteQuick` 或 `JsonOutput` 前先验证同版本能力，避免 raw bootstrap 与旧 Release 安装器错配。

--- a/docs/release-notes-2.5.1.zh-CN.md
+++ b/docs/release-notes-2.5.1.zh-CN.md
@@ -1,0 +1,28 @@
+# CX-Codex 2.5.1：修复正式 Release 一键安装
+
+这是 2.5.0 的紧急补丁版本。2.5.0 的源码和本地门禁均通过，但正式 Release zip 遗漏了 Vite 配置所需的 `local-preview.html`，导致 Windows bootstrap 在已完成 Release SHA-256 校验和依赖安装后，于前端构建阶段失败。
+
+## 修复内容
+
+- Release zip 现在同时包含 `index.html` 与 `local-preview.html`。
+- Release package smoke 强制检查两个根 HTML 入口，后续遗漏会在打标签前阻断。
+- JSON 安装模式在 npm 真正失败时继续把完整 stderr 诊断写到 stderr，同时 stdout 仍只保留一行稳定 JSON。
+- 保留 2.5.0 的全部产品化能力：`-RemoteQuick`、Release SHA-256、版本化能力清单、稳定 JSON、官方 `scripts/uninstall-windows.ps1`、托管 PID 识别和真实 StartNow/健康/卸载回归。
+- App Server schema 兼容性继续沿用 2.5.0 的候选审查边界，本补丁不扩大稳定能力声明。
+
+## 推荐操作
+
+尚未安装成功的用户直接重新执行原命令即可，bootstrap 会自动选择最新正式 Release：
+
+```powershell
+& ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/Qjzn/CX-Codex/main/scripts/bootstrap-windows.ps1'))) -RemoteQuick -JsonOutput
+```
+
+2.5.0 安装失败时会删除不完整的新安装目录；如果此前已有可用版本，更新失败会保留或恢复上一版本，不需要手工清理。
+
+## 验证要求
+
+- 从正式 2.5.1 Release 下载 zip 并验证 SHA-256。
+- 在无现有 CX-Codex 程序的 Windows 状态执行默认 bootstrap。
+- 验证安装结果版本为 2.5.1、7420 `/health` 返回 200、临时公网地址已通过健康与未登录 HTTP/WebSocket 鉴权检查。
+- 用官方卸载器确认程序和端口可清理，同时用户数据和 Codex 登录态默认保留。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cx-codex",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cx-codex",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/app": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cx-codex",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "CX-Codex Web UI and browser bridge for Windows, Linux, Android, LAN, and remote self-hosted access",
   "type": "module",
   "license": "MIT",

--- a/scripts/install-windows-server.ps1
+++ b/scripts/install-windows-server.ps1
@@ -600,7 +600,7 @@ function Invoke-Npm {
     if ($JsonOutput -and $ProgressOutput) {
       $previousErrorActionPreference = $ErrorActionPreference
       try {
-        $ErrorActionPreference = "SilentlyContinue"
+        $ErrorActionPreference = "Continue"
         & $nodeExecutable $resolvedNpmCliPath @Arguments 2>&1 |
           ForEach-Object { [Console]::Error.WriteLine([string]$_) }
         $script:NpmExitCode = $LASTEXITCODE
@@ -617,7 +617,7 @@ function Invoke-Npm {
   if ($JsonOutput -and $ProgressOutput) {
     $previousErrorActionPreference = $ErrorActionPreference
     try {
-      $ErrorActionPreference = "SilentlyContinue"
+      $ErrorActionPreference = "Continue"
       & $npmExecutable @Arguments 2>&1 |
         ForEach-Object { [Console]::Error.WriteLine([string]$_) }
       $script:NpmExitCode = $LASTEXITCODE

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -94,6 +94,7 @@ $releaseItems = @(
   "cx-codex.config.example.json",
   "docs",
   "index.html",
+  "local-preview.html",
   "package-lock.json",
   "package.json",
   "release-capabilities.json",

--- a/scripts/verify-release.ps1
+++ b/scripts/verify-release.ps1
@@ -357,6 +357,8 @@ if (-not $SkipPackageSmoke) {
     "SUPPORT.md",
     "CONTRIBUTING.md",
     "tests.md",
+    "index.html",
+    "local-preview.html",
     "docs\app-server-schema-audit-summary.json",
     "docs\app-server-protocol-matrix.zh-CN.md",
     "docs\changelog.zh-CN.md",

--- a/tests.md
+++ b/tests.md
@@ -19,6 +19,7 @@ This file tracks manual regression and feature verification steps.
 - Run `npm.cmd run verify:governance`.
 - Confirm the Windows GitHub Actions job runs the productization smoke and always invokes the official uninstall cleanup.
 - Confirm the Release zip contains `release-capabilities.json`, `scripts/uninstall-windows.ps1`, and `scripts/verify-windows-productization.ps1`.
+- Confirm the Release zip contains both Vite root entrypoints: `index.html` and `local-preview.html`.
 
 ### Evidence
 
@@ -28,6 +29,7 @@ This file tracks manual regression and feature verification steps.
 - JSON progress forwarding treats native npm/Vite stderr as diagnostics and uses the actual npm exit code, so GitHub Windows Runner warnings cannot turn a successful build into a failed install.
 - The StartNow smoke uses an isolated temporary Codex Home and synthetic local auth marker, so CI validates the 7420 lifecycle without installing Codex or opening an interactive login flow.
 - Custom config paths keep their port logs and managed PID marker under the matching state directory; official uninstall cross-checks command line, PID marker, and listening port, then waits for managed processes and retries transient Windows file locks before reporting cleanup failure.
+- 2.5.1 candidate zip was extracted into an isolated directory; `npm ci` plus frontend/CLI build passed with both `index.html` and `local-preview.html` present.
 
 ## Windows clean-install newcomer journey (2026-07-25)
 


### PR DESCRIPTION
## What changed

- include local-preview.html in the GitHub Release zip
- require both Vite root HTML entrypoints in the release package gate
- preserve native npm stderr diagnostics while using the real npm exit code
- bump the hotfix release to 2.5.1 with dedicated release notes

## Root cause

The 2.5.0 source tree and repository build passed, but scripts/package-release.ps1 did not copy local-preview.html. The verified Release zip therefore failed only after a clean bootstrap extracted it and Vite tried to resolve both configured entry modules.

## Validation

- npm.cmd run verify:governance
- npm.cmd run verify:release -- -AllowDirty -SchemaAudit skip
- extracted candidate zip into an isolated directory
- ran npm ci and npm run build inside the extracted zip
- confirmed index.html, local-preview.html, dist/index.html, and dist-cli/index.js