### PR TITLE
Fix Android keystore path on Windows runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,10 @@ jobs:
           $keystoreDir = Join-Path $env:RUNNER_TEMP 'android-signing'
           New-Item -ItemType Directory -Force -Path $keystoreDir | Out-Null
           $keystorePath = Join-Path $keystoreDir 'cx-codex-release.jks'
+          $keystorePropertiesPath = $keystorePath.Replace('\', '/')
           [System.IO.File]::WriteAllBytes($keystorePath, [Convert]::FromBase64String($env:ANDROID_KEYSTORE_BASE64))
           @"
-          storeFile=$keystorePath
+          storeFile=$keystorePropertiesPath
           storePassword=$env:ANDROID_KEYSTORE_PASSWORD
           keyAlias=$env:ANDROID_KEY_ALIAS
           keyPassword=$env:ANDROID_KEY_PASSWORD

--- a/scripts/verify-governance.ps1
+++ b/scripts/verify-governance.ps1
@@ -645,6 +645,7 @@ Assert-ContentIncludes ".github/workflows/release.yml" @(
   "Release tag `$env:GITHUB_REF_NAME does not match package version `$packageVersion.",
   "docs/release-notes-`$tagVersion.zh-CN.md",
   "Require Android release signing secrets",
+  "keystorePath.Replace('\', '/')",
   "Verify Android release signature",
   "ANDROID_RELEASE_CERT_SHA256",
   'body_path: ${{ steps.release-metadata.outputs.release_notes_path }}'


### PR DESCRIPTION
## Root cause

The release workflow wrote the Windows Runner keystore path directly into a Java `.properties` file. Java properties treats backslashes as escapes, turning the valid Runner path into a nonexistent Gradle signing path.

## Fix

- normalize the keystore path to forward slashes before writing `android/keystore.properties`
- add a governance assertion so the Windows-safe normalization cannot silently regress

## Verification

- reproduced from failed release run `30161980646`
- signing secrets were present and decoded successfully; failure occurred only at Gradle `validateSigningRelease`
- `npm.cmd run verify:governance`
- `git diff --check`