### PR TITLE
 fix: 修复 fork PR 的 Windows bootstrap 取源逻辑

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
 
       - name: Run locked in-place upgrade smoke test
         shell: pwsh
+        env:
+          SOURCE_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           $installDir = "$env:TEMP\cx-codex-smoke-install"
           $distCliDir = Join-Path $installDir "dist-cli"
@@ -121,14 +124,22 @@ jobs:
             if (-not $listener -or [int]$listener.OwningProcess -ne $lockProcess.Id) {
               throw "Upgrade fixture did not acquire the expected listener and PID marker."
             }
-            $branch = if ($env:GITHUB_HEAD_REF) { $env:GITHUB_HEAD_REF } else { $env:GITHUB_REF_NAME }
+            if ($env:SOURCE_REPOSITORY -notmatch '^[^/]+/[^/]+$') {
+              throw "Source repository must use the owner/name format."
+            }
+            if ([string]::IsNullOrWhiteSpace($env:SOURCE_BRANCH)) {
+              throw "Source branch must not be empty."
+            }
+            $repoOwner, $repoName = $env:SOURCE_REPOSITORY -split '/', 2
             $jsonLines = @(
               ./scripts/bootstrap-windows.ps1 `
                 -InstallDir $installDir `
                 -WorkspacePath "$env:TEMP\CodexWorkspace" `
                 -Port 7441 `
                 -Password "ci-password" `
-                -Branch $branch `
+                -RepoOwner $repoOwner `
+                -RepoName $repoName `
+                -Branch $env:SOURCE_BRANCH `
                 -UseBranchArchive `
                 -SkipStartupTask `
                 -SkipWatchdogTask `


### PR DESCRIPTION
## 修复内容

修复 Windows locked in-place upgrade smoke 在 fork PR 场景下使用错误源码仓库的问题。

此前 workflow 只向 bootstrap 传递 PR 的 head branch，但没有传递 fork head repository 的 owner 和 name。bootstrap 因此继续使用默认的 `Qjzn/CX-Codex`，尝试从上游仓库下载仅存在于 fork 的分支，最终返回 404。

本次修改：

- pull request 场景使用 fork head repository 和 head branch
- push 场景回退到当前 repository 和 ref
- 校验源仓库必须符合 `owner/name` 格式
- 将 `RepoOwner`、`RepoName` 和 `Branch` 一起传给现有 bootstrap 脚本
- 不修改 bootstrap 脚本公共接口

## 验证

- `npm.cmd run verify:windows-productization`
- `npm.cmd run verify:release -- -SchemaAudit skip`
- `npm.cmd run verify:governance`
- workflow YAML 解析
- fork PR 与 push 参数输入模拟
- `git diff --check`