### PR TITLE
fix: duplicate messages rendered twice while a thread runs

### DIFF
--- a/scripts/verify-frontend-normalizers.mjs
+++ b/scripts/verify-frontend-normalizers.mjs
@@ -1019,6 +1019,55 @@ assert.deepEqual(
   ).map((message) => message.id),
   ['same-text-turn-1', 'same-text-turn-2'],
 )
+
+// Cross-source duplicate projection: the same logical messages can arrive with
+// different ids (App Server response-item ids like "item-1" versus session-log
+// message ids like "msg_..."). Merging both must collapse to one copy per
+// message instead of rendering each twice.
+const sessionLogProjection = [
+  { id: 'msg_user_1', role: 'user', text: 'hello duplicate', messageType: 'userMessage', turnIndex: 0 },
+  { id: 'msg_user_1:assistant:2', role: 'assistant', text: 'hi there', messageType: 'agentMessage', phase: 'final', turnIndex: 0 },
+]
+const appServerProjection = [
+  { id: 'item-1', role: 'user', text: 'hello duplicate', messageType: 'userMessage', turnIndex: 0 },
+  { id: 'item-2', role: 'assistant', text: 'hi there', messageType: 'agentMessage', phase: 'final', turnIndex: 0 },
+]
+assert.deepEqual(
+  mergeMessages(sessionLogProjection, appServerProjection, true, false, false, false).map((message) => message.id),
+  ['item-1', 'item-2'],
+)
+assert.deepEqual(
+  mergeMessages(appServerProjection, sessionLogProjection, true, false, false, false).map((message) => message.id),
+  ['msg_user_1', 'msg_user_1:assistant:2'],
+)
+// Identical text at distinct turns must never be collapsed.
+assert.deepEqual(
+  mergeMessages(
+    [{ id: 'msg_same_turn_1', role: 'user', text: 'repeat', messageType: 'userMessage', turnIndex: 1 }],
+    [{ id: 'item_same_turn_2', role: 'user', text: 'repeat', messageType: 'userMessage', turnIndex: 2 }],
+    true,
+    false,
+    false,
+    false,
+  ).map((message) => message.id),
+  ['msg_same_turn_1', 'item_same_turn_2'],
+)
+// A partial incoming array must not drop previous copies it does not represent.
+assert.deepEqual(
+  mergeMessages(
+    [
+      { id: 'msg_a', role: 'user', text: 'first', messageType: 'userMessage', turnIndex: 0 },
+      { id: 'msg_b', role: 'user', text: 'second', messageType: 'userMessage', turnIndex: 1 },
+    ],
+    [{ id: 'item-a', role: 'user', text: 'first', messageType: 'userMessage', turnIndex: 0 }],
+    true,
+    false,
+    false,
+    false,
+  ).map((message) => message.id),
+  ['msg_b', 'item-a'],
+)
+
 const laterHistoryMessages = [historyNoticeMessage, projectedTurnTwo]
 assert.equal(removeStaleHistoryNoticeAfterOlderMerge(laterHistoryMessages), laterHistoryMessages)
 assert.deepEqual(

--- a/src/composables/conversationProjection.ts
+++ b/src/composables/conversationProjection.ts
@@ -177,11 +177,63 @@ export function mergeMessages(
 
   const previousIdSet = new Set(previous.map((message) => message.id))
   const appended = mergedIncoming.filter((message) => !previousIdSet.has(message.id))
+  const dedupedFromPrevious = dedupeProjectionAgainstIncoming(
+    mergedFromPrevious,
+    appended,
+    incomingById,
+  )
   const merged = sortByTurnIndex
-    ? sortMessagesByTurnIndex([...mergedFromPrevious, ...appended])
-    : [...mergedFromPrevious, ...appended]
+    ? sortMessagesByTurnIndex([...dedupedFromPrevious, ...appended])
+    : [...dedupedFromPrevious, ...appended]
 
   return areMessageArraysEqual(previous, merged) ? previous : merged
+}
+
+function messageContentIdentity(message: UiMessage): string {
+  const turnIndex = typeof message.turnIndex === 'number' ? String(message.turnIndex) : ''
+  const text = normalizeMessageText(message.text)
+  const images = (message.images ?? [])
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    .join('\u001f')
+  const filePaths = (message.fileAttachments ?? [])
+    .map((file) => `${file.label.trim()}\u001e${file.path.trim()}`)
+    .join('\u001f')
+  const phase = message.phase ?? ''
+  return [message.role, message.messageType ?? '', phase, turnIndex, text, images, filePaths].join('\u001d')
+}
+
+/**
+ * The same logical message can be delivered under different ids by different
+ * sources (e.g. App Server response-item ids like "item-1" versus session-log
+ * message ids like "msg_..."). When the incoming array fully represents a
+ * content identity, drop the stale previous copy so the message does not
+ * render twice. Copies at distinct turns are never collapsed because their
+ * turnIndex differs, and partially-synced incoming arrays keep previous extras.
+ */
+function dedupeProjectionAgainstIncoming(
+  previous: UiMessage[],
+  appended: UiMessage[],
+  incomingById: ReadonlyMap<string, UiMessage>,
+): UiMessage[] {
+  const previousIdentityCounts = new Map<string, number>()
+  for (const message of previous) {
+    if (incomingById.has(message.id)) continue
+    const key = messageContentIdentity(message)
+    previousIdentityCounts.set(key, (previousIdentityCounts.get(key) ?? 0) + 1)
+  }
+  const appendedIdentityCounts = new Map<string, number>()
+  for (const message of appended) {
+    const key = messageContentIdentity(message)
+    appendedIdentityCounts.set(key, (appendedIdentityCounts.get(key) ?? 0) + 1)
+  }
+  return previous.filter((message) => {
+    if (incomingById.has(message.id)) return true
+    const key = messageContentIdentity(message)
+    const previousCount = previousIdentityCounts.get(key) ?? 0
+    const appendedCount = appendedIdentityCounts.get(key) ?? 0
+    return appendedCount < previousCount
+  })
 }
 
 export function earliestTurnIndexFromMessages(messages: UiMessage[]): number | null {

--- a/src/server/appServerSessionLogThreadRead.ts
+++ b/src/server/appServerSessionLogThreadRead.ts
@@ -186,7 +186,9 @@ function isInternalContextMessageText(text: string): boolean {
     text.startsWith('<codex_internal_context') ||
     text.startsWith('<environment_context') ||
     text.startsWith('<developer_context') ||
-    text.startsWith('<system_context')
+    text.startsWith('<system_context') ||
+    text.startsWith('# AGENTS.md instructions') ||
+    text.startsWith('<INSTRUCTIONS>')
   )
 }
 
@@ -235,6 +237,11 @@ function readEventMessage(entry: Record<string, unknown>): RecoveredMessage | nu
 }
 
 function appendMessageTurn(turns: FallbackTurn[], message: RecoveredMessage): void {
+  // Hidden internal-context messages (e.g. injected AGENTS.md prompts) are
+  // omitted by the App Server thread read; skipping them here keeps the
+  // fallback turn indexes aligned with the App Server view.
+  if (message.hidden) return
+
   const text = limitText(message.text)
   const turn = message.role === 'user' || turns.length === 0
     ? null
@@ -245,8 +252,6 @@ function appendMessageTurn(turns: FallbackTurn[], message: RecoveredMessage): vo
     items: [],
   }
   if (!turn) turns.push(targetTurn)
-
-  if (message.hidden) return
 
   const itemId = message.id || `${targetTurn.id}:${message.role}:${String(targetTurn.items.length + 1)}`
   targetTurn.items.push(message.role === 'user'


### PR DESCRIPTION
﻿## Problem

While a Codex task is running (and also after it settles), **every user message and assistant reply is rendered twice** in both the Android app and the web UI. The duplicate rows carry different ids (`item-1`/`item-2` from the App Server response items vs `msg_...`/`msg_...:assistant:2` from the session-log fallback) but the same content.

## Root cause

The frontend loads thread messages from two sources with different id schemes **and different turn structures**:

1. `/codex-api/state/thread/<id>` (runtime snapshot) prefers the **session-log fallback**, which returns messages with stable session ids (`msg_...`) and treats injected internal-context user messages (the `AGENTS.md instructions` prompt) as a real user turn.
2. `thread/read` RPC returns the App Server view with response-item ids (`item-1`, `item-2`) and without the internal-context turn.

Because of the extra internal-context turn, the two sources assign **different `turnIndex` values** to the same logical messages. `mergeMessages` only deduplicates by id, so while `preserveMissing` is active (running/settling threads) both copies survive and every message renders twice.

## Changes

- **`src/composables/conversationProjection.ts`**: when merging a projection with preserve-missing semantics, drop a stale previous copy whenever the incoming array fully represents the same message identity (role + messageType + phase + turnIndex + normalized text + images + file attachments). Distinct turns with identical text are never collapsed, and partial syncs keep previous extras (result count never drops below either source's count).
- **`src/server/appServerSessionLogThreadRead.ts`**: recognize the injected `AGENTS.md instructions` prompt as internal context, and stop creating fallback turns for hidden internal-context messages. This keeps the session-log fallback turn structure aligned with the App Server thread read so the ids/turnIndexes line up for dedup.

## Verification

- Added regression tests to `scripts/verify-frontend-normalizers.mjs` covering: session-log + App Server projections collapsing to one copy (both directions), distinct turns with identical text staying intact, and partial incoming arrays keeping previous extras.
- `npm run verify:frontend-normalizers` passes.
- `vue-tsc --noEmit` passes; `npm run build` succeeds.
- Reproduced on a live 2.7.6 server (fresh browser, mobile viewport): before the fix a test send rendered the user message and reply **twice each** (marker count 4); after the fix both render **once each** (marker count 2), with no console errors.
