### PR TITLE
fix(windows): 改进计划任务运行时

### DIFF
--- a/scripts/install-windows-server.ps1
+++ b/scripts/install-windows-server.ps1
@@ -519,14 +519,37 @@ URL=$shortcutUrl
 function Register-StartupTask {
   param(
     [string]$ResolvedTaskName,
-    [string]$TargetLauncherPath
+    [string]$TargetLauncherPath,
+    [string]$RepoRoot
   )
 
-  $taskRun = "cmd.exe /c `"$TargetLauncherPath`""
-  $output = & schtasks.exe /Create /F /SC ONLOGON /RL HIGHEST /TN $ResolvedTaskName /TR $taskRun 2>&1
-  if ($LASTEXITCODE -ne 0) {
-    $details = ($output | Out-String).Trim()
-    throw "Failed to create scheduled task $ResolvedTaskName. $details"
+  $hiddenCommandRunner = Join-Path $RepoRoot "scripts\run-hidden-command.vbs"
+  $wscriptPath = Join-Path $env:SystemRoot "System32\wscript.exe"
+  $cmdPath = Join-Path $env:SystemRoot "System32\cmd.exe"
+  foreach ($requiredPath in @($hiddenCommandRunner, $wscriptPath, $cmdPath)) {
+    if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+      throw "Startup task runtime not found: $requiredPath"
+    }
+  }
+
+  $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+  $actionArguments = @(
+    "//B", "//NoLogo", $hiddenCommandRunner, $cmdPath, "/d", "/c", $TargetLauncherPath
+  ) | ForEach-Object { ConvertTo-WindowsProcessArgument -Value ([string]$_) }
+  $action = New-ScheduledTaskAction -Execute $wscriptPath -Argument ($actionArguments -join " ")
+  $trigger = New-ScheduledTaskTrigger -AtLogOn -User $currentUser
+  $settings = New-ScheduledTaskSettingsSet
+  $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Interactive -RunLevel Limited
+  try {
+    Register-ScheduledTask `
+      -TaskName $ResolvedTaskName `
+      -Action $action `
+      -Trigger $trigger `
+      -Settings $settings `
+      -Principal $principal `
+      -Force | Out-Null
+  } catch {
+    throw "Failed to create scheduled task $ResolvedTaskName. $($_.Exception.Message)"
   }
 }
 
@@ -539,16 +562,38 @@ function Register-WatchdogTask {
     [string]$NodePath
   )
 
+  $hiddenPowerShellRunner = Join-Path $RepoRoot "scripts\run-hidden-powershell.vbs"
   $watchdogScript = Join-Path $RepoRoot "scripts\watchdog-7420.ps1"
-  if (-not (Test-Path -LiteralPath $watchdogScript)) {
-    throw "Watchdog script not found: $watchdogScript"
+  $wscriptPath = Join-Path $env:SystemRoot "System32\wscript.exe"
+  foreach ($requiredPath in @($hiddenPowerShellRunner, $watchdogScript, $wscriptPath)) {
+    if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+      throw "Watchdog task runtime not found: $requiredPath"
+    }
   }
 
-  $taskRun = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$watchdogScript`" -Port $TargetPort -ConfigPath `"$TargetConfigPath`" -NodePath `"$NodePath`" -RepoRoot `"$RepoRoot`""
-  $output = & schtasks.exe /Create /F /SC MINUTE /MO 1 /TN $ResolvedTaskName /TR $taskRun 2>&1
-  if ($LASTEXITCODE -ne 0) {
-    $details = ($output | Out-String).Trim()
-    throw "Failed to create scheduled task $ResolvedTaskName. $details"
+  $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+  $actionArguments = @(
+    "//B", "//NoLogo", $hiddenPowerShellRunner, $watchdogScript,
+    "-Port", "$TargetPort", "-ConfigPath", $TargetConfigPath,
+    "-NodePath", $NodePath, "-RepoRoot", $RepoRoot
+  ) | ForEach-Object { ConvertTo-WindowsProcessArgument -Value ([string]$_) }
+  $action = New-ScheduledTaskAction -Execute $wscriptPath -Argument ($actionArguments -join " ")
+  $trigger = New-ScheduledTaskTrigger `
+    -Once `
+    -At ((Get-Date).AddMinutes(1)) `
+    -RepetitionInterval (New-TimeSpan -Minutes 1)
+  $settings = New-ScheduledTaskSettingsSet
+  $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Interactive -RunLevel Limited
+  try {
+    Register-ScheduledTask `
+      -TaskName $ResolvedTaskName `
+      -Action $action `
+      -Trigger $trigger `
+      -Settings $settings `
+      -Principal $principal `
+      -Force | Out-Null
+  } catch {
+    throw "Failed to create scheduled task $ResolvedTaskName. $($_.Exception.Message)"
   }
 }
 
@@ -1046,7 +1091,7 @@ $managementShortcutPaths = @(Create-ManagementShortcuts -TargetPort $Port)
 if ($CreateStartupTask) {
   Write-Step "Creating startup task"
   try {
-    Register-StartupTask -ResolvedTaskName $resolvedTaskName -TargetLauncherPath $LauncherPath
+    Register-StartupTask -ResolvedTaskName $resolvedTaskName -TargetLauncherPath $LauncherPath -RepoRoot $repoRoot
     Write-InstallerMessage "Scheduled task created: $resolvedTaskName"
   } catch {
     Write-InstallerWarning -Code "STARTUP_TASK_FAILED" -Message $_

--- a/scripts/run-hidden-command.vbs
+++ b/scripts/run-hidden-command.vbs
@@ -1,0 +1,60 @@
+Option Explicit
+
+Const ExitMissingCommandArgument = 2
+Const ExitCommandNotFound = 3
+
+Dim arguments
+Dim fileSystem
+Dim shell
+Dim commandPath
+Dim command
+Dim index
+
+Set arguments = WScript.Arguments
+Set fileSystem = CreateObject("Scripting.FileSystemObject")
+Set shell = CreateObject("WScript.Shell")
+
+If arguments.Count < 1 Then
+  WScript.Quit ExitMissingCommandArgument
+End If
+
+commandPath = fileSystem.GetAbsolutePathName(arguments.Item(0))
+If Not fileSystem.FileExists(commandPath) Then
+  WScript.Quit ExitCommandNotFound
+End If
+
+command = QuoteArgument(commandPath)
+For index = 1 To arguments.Count - 1
+  command = command & " " & QuoteArgument(arguments.Item(index))
+Next
+
+WScript.Quit shell.Run(command, 0, True)
+
+Function QuoteArgument(ByVal value)
+  Dim result
+  Dim backslashCount
+  Dim position
+  Dim character
+
+  result = Chr(34)
+  backslashCount = 0
+  For position = 1 To Len(value)
+    character = Mid(value, position, 1)
+    If character = "\" Then
+      backslashCount = backslashCount + 1
+    ElseIf character = Chr(34) Then
+      result = result & String((backslashCount * 2) + 1, "\") & Chr(34)
+      backslashCount = 0
+    Else
+      If backslashCount > 0 Then
+        result = result & String(backslashCount, "\")
+        backslashCount = 0
+      End If
+      result = result & character
+    End If
+  Next
+  If backslashCount > 0 Then
+    result = result & String(backslashCount * 2, "\")
+  End If
+  QuoteArgument = result & Chr(34)
+End Function

--- a/scripts/run-hidden-powershell.vbs
+++ b/scripts/run-hidden-powershell.vbs
@@ -1,0 +1,69 @@
+Option Explicit
+
+Const ExitMissingScriptArgument = 2
+Const ExitScriptNotFound = 3
+Const ExitPowerShellNotFound = 4
+
+Dim arguments
+Dim fileSystem
+Dim shell
+Dim scriptPath
+Dim powershellPath
+Dim command
+Dim index
+
+Set arguments = WScript.Arguments
+Set fileSystem = CreateObject("Scripting.FileSystemObject")
+Set shell = CreateObject("WScript.Shell")
+
+If arguments.Count < 1 Then
+  WScript.Quit ExitMissingScriptArgument
+End If
+
+scriptPath = fileSystem.GetAbsolutePathName(arguments.Item(0))
+If Not fileSystem.FileExists(scriptPath) Then
+  WScript.Quit ExitScriptNotFound
+End If
+
+powershellPath = shell.ExpandEnvironmentStrings("%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe")
+If Not fileSystem.FileExists(powershellPath) Then
+  WScript.Quit ExitPowerShellNotFound
+End If
+
+command = QuoteArgument(powershellPath) _
+  & " -NoProfile -NonInteractive -ExecutionPolicy Bypass -File " _
+  & QuoteArgument(scriptPath)
+For index = 1 To arguments.Count - 1
+  command = command & " " & QuoteArgument(arguments.Item(index))
+Next
+
+WScript.Quit shell.Run(command, 0, True)
+
+Function QuoteArgument(ByVal value)
+  Dim result
+  Dim backslashCount
+  Dim position
+  Dim character
+
+  result = Chr(34)
+  backslashCount = 0
+  For position = 1 To Len(value)
+    character = Mid(value, position, 1)
+    If character = "\" Then
+      backslashCount = backslashCount + 1
+    ElseIf character = Chr(34) Then
+      result = result & String((backslashCount * 2) + 1, "\") & Chr(34)
+      backslashCount = 0
+    Else
+      If backslashCount > 0 Then
+        result = result & String(backslashCount, "\")
+        backslashCount = 0
+      End If
+      result = result & character
+    End If
+  Next
+  If backslashCount > 0 Then
+    result = result & String(backslashCount * 2, "\")
+  End If
+  QuoteArgument = result & Chr(34)
+End Function

--- a/scripts/verify-release.ps1
+++ b/scripts/verify-release.ps1
@@ -376,6 +376,8 @@ if (-not $SkipPackageSmoke) {
     "docs\roadmap.zh-CN.md",
     "docs\security-hardening.zh-CN.md",
     "scripts\package-release.ps1",
+    "scripts\run-hidden-command.vbs",
+    "scripts\run-hidden-powershell.vbs",
     "scripts\start-detached-server.mjs",
     "scripts\uninstall-windows.ps1",
     "scripts\verify-windows-productization.ps1",

--- a/scripts/verify-windows-productization.ps1
+++ b/scripts/verify-windows-productization.ps1
@@ -87,12 +87,28 @@ $installScript = Join-Path $repoRoot "scripts\install-windows-server.ps1"
 $uninstallScript = Join-Path $repoRoot "scripts\uninstall-windows.ps1"
 $bootstrapScript = Join-Path $repoRoot "scripts\bootstrap-windows.ps1"
 $restartScript = Join-Path $repoRoot "scripts\restart-local-service.ps1"
+$hiddenCommandRunner = Join-Path $repoRoot "scripts\run-hidden-command.vbs"
+$hiddenPowerShellRunner = Join-Path $repoRoot "scripts\run-hidden-powershell.vbs"
 $cliScript = Join-Path $repoRoot "src\cli\index.ts"
 $testRoot = Join-Path $env:TEMP "cx-codex-productization-$PID"
 $installSource = Get-Content -LiteralPath $installScript -Raw
 $bootstrapSource = Get-Content -LiteralPath $bootstrapScript -Raw
 $restartSource = Get-Content -LiteralPath $restartScript -Raw
 $cliSource = Get-Content -LiteralPath $cliScript -Raw
+$hiddenCommandSource = Get-Content -LiteralPath $hiddenCommandRunner -Raw
+$hiddenPowerShellSource = Get-Content -LiteralPath $hiddenPowerShellRunner -Raw
+Assert-True `
+  ($installSource -match 'New-ScheduledTaskPrincipal[\s\S]*?-LogonType\s+Interactive[\s\S]*?-RunLevel\s+Limited' -and $installSource -notmatch 'schtasks\.exe\s+/Create') `
+  "Windows startup and watchdog tasks must use the ScheduledTasks API with the current interactive user at limited privilege."
+Assert-True `
+  ($installSource -match 'run-hidden-command\.vbs[\s\S]*?New-ScheduledTaskAction[\s\S]*?wscriptPath' -and $installSource -match 'run-hidden-powershell\.vbs[\s\S]*?New-ScheduledTaskAction[\s\S]*?wscriptPath') `
+  "Windows scheduled tasks must use hidden WScript runtime adapters."
+Assert-True `
+  ($hiddenCommandSource -match 'shell\.Run\(command,\s*0,\s*True\)' -and $hiddenCommandSource -match 'Function\s+QuoteArgument') `
+  "Hidden command runtime must wait for completion and preserve Windows argument quoting."
+Assert-True `
+  ($hiddenPowerShellSource -match '-NonInteractive' -and $hiddenPowerShellSource -match 'shell\.Run\(command,\s*0,\s*True\)' -and $hiddenPowerShellSource -match 'Function\s+QuoteArgument') `
+  "Hidden PowerShell runtime must be non-interactive, wait for completion, and preserve long arguments."
 Assert-True `
   ($installSource -match "function\s+Wait-ForTunnelReadyState") `
   "Windows installer must wait for the runtime tunnel readiness state."

--- a/tests.md
+++ b/tests.md
@@ -15887,3 +15887,16 @@ Current evidence:
 - The foreground restart-policy test failed before the fix because a selected idle conversation forced a restart; it passes after requiring actual sync demand for a connected stale stream.
 - The full 38-surface regression passed in 499.7 seconds. The built-in stress probe mounted 13 of 1602 messages with 64ms maximum lag and accepted interaction while output continued.
 - Independent headless Playwright mounted 12 of 1602 messages with 47ms maximum lag; the action count increased by one, updates continued from 76 to 84, and console/request failure lists were empty.
+
+## Windows 计划任务安全运行时
+
+1. 登录启动任务和 watchdog 必须通过 PowerShell ScheduledTasks API 注册到当前用户，使用 `Interactive` 登录类型和 `Limited` 运行级别，不再请求最高权限。
+2. 登录启动动作必须通过 `wscript.exe //B //NoLogo scripts/run-hidden-command.vbs` 启动绝对路径的 `cmd.exe /d /c`；watchdog 必须通过对应的 `run-hidden-powershell.vbs` 启动。
+3. 两个 VBS 运行器必须验证目标文件存在，正确转义带空格、引号和尾部反斜杠的参数，隐藏窗口并把子进程退出码返回给计划任务。
+4. Release ZIP 必须包含两个运行器；缺少任一文件时发布校验应失败。
+
+Verification:
+
+- Run `npm.cmd run verify:windows-productization` without registering or changing the machine's real CX-Codex scheduled tasks.
+- Run `npm.cmd run verify:release -- -SkipBuild -SkipCliSmoke` after existing build output is available to exercise the Release ZIP manifest.
+- Confirm the changed files are UTF-8 without BOM and inspect the PowerShell diff for intact task arguments.


### PR DESCRIPTION
## 变更说明

- 使用 PowerShell ScheduledTasks API 注册登录启动和 watchdog 任务，不再通过 `schtasks.exe /Create`
- 将任务限定为当前交互用户、`Interactive` 登录类型和 `Limited` 运行级别
- 通过两个 `wscript.exe` 运行适配器隐藏命令窗口，并保留参数转义、等待和退出码语义
- 将新增运行器纳入 Release ZIP 清单和 Windows 产品化验证
- 安装脚本失败时保留原有警告与回滚边界；本次验证未注册或修改真实计划任务

## 验证结果

- [ ] `npm run build`（未运行完整构建；本变更不涉及前端或 CLI TypeScript）
- [x] `npm.cmd run verify:windows-productization`
- [x] `npm.cmd run verify:release -- -SkipBuild -SkipCliSmoke`
- [x] PowerShell 语法解析、UTF-8/BOM 检查和 `git diff --check`
- [ ] 单元测试（按本次工作约束未运行）

## 隐私与安全

- [x] 不包含密码、Token、Cookie、私有 IP、真实公网地址或个人目录
- [x] 不写死个人配置、私人服务器地址或本地路径
- [x] 不新增远程访问能力