### PR TITLE
feat(cli): 新增 Windows 服务管理命令

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
   "files": [
     "dist/",
     "dist-cli/",
-    "docs/app-server-schema-audit-summary.json"
+    "docs/app-server-schema-audit-summary.json",
+    "scripts/run-powershell-script.mjs",
+    "scripts/manage-windows-service.ps1"
   ],
   "scripts": {
     "dev": "vite",

--- a/scripts/manage-windows-service.ps1
+++ b/scripts/manage-windows-service.ps1
@@ -1,0 +1,558 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("start", "stop", "restart", "status", "enable", "disable")]
+  [string]$Action,
+  [Parameter(Mandatory = $true)]
+  [ValidateRange(1, 65535)]
+  [int]$Port,
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$ConfigPath,
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$LauncherPath,
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$TaskName,
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$WatchdogTaskName,
+  [ValidateSet("Human", "Json")]
+  [string]$OutputFormat = "Human",
+  [ValidateRange(1, 300)]
+  [int]$HealthTimeoutSeconds = 15
+)
+
+$ErrorActionPreference = "Stop"
+$script:ExitCodes = @{
+  OK = 0
+  INTERNAL_ERROR = 1
+  INVALID_ARGUMENT = 2
+  UNSUPPORTED_PLATFORM = 3
+  MISSING_INSTALL_RESOURCE = 4
+  UNMANAGED_PORT_CONFLICT = 5
+  PROCESS_CONTROL_FAILED = 6
+  HEALTH_TIMEOUT = 7
+  SYSTEM_INSPECTION_FAILED = 8
+}
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class CxCodexWindowsCommandLine
+{
+    [DllImport("shell32.dll", SetLastError = true)]
+    public static extern IntPtr CommandLineToArgvW([MarshalAs(UnmanagedType.LPWStr)] string commandLine, out int argumentCount);
+
+    [DllImport("kernel32.dll")]
+    public static extern IntPtr LocalFree(IntPtr memory);
+}
+"@
+
+function New-ServiceFailure {
+  param(
+    [string]$Code,
+    [string]$Message
+  )
+  $exception = [System.InvalidOperationException]::new($Message)
+  $exception.Data["ServiceCode"] = $Code
+  return $exception
+}
+
+function Get-NormalizedPath {
+  param(
+    [string]$Path,
+    [string]$Label
+  )
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    throw (New-ServiceFailure -Code "INVALID_ARGUMENT" -Message "$Label must not be empty.")
+  }
+  try {
+    return [System.IO.Path]::GetFullPath($Path)
+  } catch {
+    throw (New-ServiceFailure -Code "INVALID_ARGUMENT" -Message "$Label is not a valid path.")
+  }
+}
+
+function Split-WindowsCommandLine {
+  param([string]$CommandLine)
+  $argumentCount = 0
+  $argumentPointer = [CxCodexWindowsCommandLine]::CommandLineToArgvW($CommandLine, [ref]$argumentCount)
+  if ($argumentPointer -eq [IntPtr]::Zero) {
+    throw (New-ServiceFailure -Code "SYSTEM_INSPECTION_FAILED" -Message "Could not parse a Windows process command line.")
+  }
+  try {
+    $arguments = New-Object 'System.Collections.Generic.List[string]'
+    for ($index = 0; $index -lt $argumentCount; $index += 1) {
+      $itemPointer = [System.Runtime.InteropServices.Marshal]::ReadIntPtr($argumentPointer, $index * [IntPtr]::Size)
+      $arguments.Add([System.Runtime.InteropServices.Marshal]::PtrToStringUni($itemPointer)) | Out-Null
+    }
+    return @($arguments)
+  } finally {
+    [CxCodexWindowsCommandLine]::LocalFree($argumentPointer) | Out-Null
+  }
+}
+
+function Test-ManagedServerCommandLine {
+  param(
+    [string]$CommandLine,
+    [string[]]$ManagedPaths
+  )
+  if ([string]::IsNullOrWhiteSpace($CommandLine)) {
+    return $false
+  }
+  $arguments = @(Split-WindowsCommandLine -CommandLine $CommandLine)
+  $entryIndex = -1
+  for ($index = 0; $index -lt $arguments.Count; $index += 1) {
+    $normalizedArgument = ([string]$arguments[$index]).Replace('\', '/')
+    if ($normalizedArgument.EndsWith("/dist-cli/index.js", [System.StringComparison]::OrdinalIgnoreCase)) {
+      $entryIndex = $index
+      break
+    }
+  }
+  if ($entryIndex -lt 0) {
+    return $false
+  }
+  if (
+    $entryIndex + 1 -lt $arguments.Count -and
+    ([string]$arguments[$entryIndex + 1]).Equals("service", [System.StringComparison]::OrdinalIgnoreCase)
+  ) {
+    return $false
+  }
+  foreach ($managedPath in $ManagedPaths) {
+    $normalizedManagedPath = [System.IO.Path]::GetFullPath($managedPath).TrimEnd('\')
+    foreach ($argument in $arguments) {
+      try {
+        $normalizedArgumentPath = [System.IO.Path]::GetFullPath([string]$argument).TrimEnd('\')
+        if ($normalizedArgumentPath.Equals($normalizedManagedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+          return $true
+        }
+      } catch {
+        continue
+      }
+    }
+  }
+  return $false
+}
+
+function Get-ExactScheduledTask {
+  param([string]$Name)
+  try {
+    $tasks = @(
+      Get-ScheduledTask -ErrorAction Stop |
+        Where-Object { ([string]$_.TaskName).Equals($Name, [System.StringComparison]::OrdinalIgnoreCase) }
+    )
+  } catch {
+    throw (New-ServiceFailure -Code "SYSTEM_INSPECTION_FAILED" -Message "Could not inspect scheduled task '$Name'.")
+  }
+  if ($tasks.Count -gt 1) {
+    throw (New-ServiceFailure -Code "SYSTEM_INSPECTION_FAILED" -Message "Scheduled task name '$Name' is ambiguous across task paths.")
+  }
+  return $tasks | Select-Object -First 1
+}
+
+function Get-TaskFact {
+  param([string]$Name)
+  $task = Get-ExactScheduledTask -Name $Name
+  if (-not $task) {
+    return [pscustomobject][ordered]@{
+      name = $Name
+      exists = $false
+      enabled = $false
+      state = "Missing"
+    }
+  }
+  return [pscustomobject][ordered]@{
+    name = $Name
+    exists = $true
+    enabled = [bool]$task.Settings.Enabled
+    state = [string]$task.State
+  }
+}
+
+function Get-HealthFact {
+  param([int]$ServicePort)
+  $url = "http://127.0.0.1:$ServicePort/health"
+  $ready = $false
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -Uri $url -TimeoutSec 2 -ErrorAction Stop
+    $ready = [int]$response.StatusCode -eq 200
+  } catch {
+    $ready = $false
+  }
+  return [pscustomobject][ordered]@{
+    ready = $ready
+    url = $url
+  }
+}
+
+function Add-ProcessTreePreOrder {
+  param(
+    [int]$RootProcessId,
+    [object[]]$Processes,
+    [System.Collections.Generic.HashSet[int]]$Visited,
+    [System.Collections.Generic.List[int]]$Ordered
+  )
+  if ($RootProcessId -le 0 -or $RootProcessId -eq $PID -or -not $Visited.Add($RootProcessId)) {
+    return
+  }
+  $Ordered.Add($RootProcessId) | Out-Null
+  foreach ($child in @($Processes | Where-Object { [int]$_.ParentProcessId -eq $RootProcessId })) {
+    Add-ProcessTreePreOrder -RootProcessId ([int]$child.ProcessId) -Processes $Processes -Visited $Visited -Ordered $Ordered
+  }
+}
+
+function Add-ProcessTreePostOrder {
+  param(
+    [int]$RootProcessId,
+    [object[]]$Processes,
+    [System.Collections.Generic.HashSet[int]]$Visited,
+    [System.Collections.Generic.List[int]]$Ordered
+  )
+  if ($RootProcessId -le 0 -or $RootProcessId -eq $PID -or -not $Visited.Add($RootProcessId)) {
+    return
+  }
+  foreach ($child in @($Processes | Where-Object { [int]$_.ParentProcessId -eq $RootProcessId })) {
+    Add-ProcessTreePostOrder -RootProcessId ([int]$child.ProcessId) -Processes $Processes -Visited $Visited -Ordered $Ordered
+  }
+  $Ordered.Add($RootProcessId) | Out-Null
+}
+
+function Get-ServiceSnapshot {
+  try {
+    $processes = @(Get-CimInstance Win32_Process -ErrorAction Stop)
+  } catch {
+    throw (New-ServiceFailure -Code "SYSTEM_INSPECTION_FAILED" -Message "Could not inspect Windows processes.")
+  }
+  try {
+    $listeners = @(Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue)
+  } catch {
+    throw (New-ServiceFailure -Code "SYSTEM_INSPECTION_FAILED" -Message "Could not inspect TCP listeners for port $Port.")
+  }
+
+  $managedRoots = New-Object 'System.Collections.Generic.List[int]'
+  foreach ($processInfo in $processes) {
+    $processId = [int]$processInfo.ProcessId
+    if ($processId -le 0 -or $processId -eq $PID) {
+      continue
+    }
+    if (Test-ManagedServerCommandLine -CommandLine ([string]$processInfo.CommandLine) -ManagedPaths $script:ManagedIdentityPaths) {
+      $managedRoots.Add($processId) | Out-Null
+    }
+  }
+
+  $managedVisited = New-Object 'System.Collections.Generic.HashSet[int]'
+  $managedOrdered = New-Object 'System.Collections.Generic.List[int]'
+  foreach ($managedRoot in $managedRoots) {
+    Add-ProcessTreePreOrder -RootProcessId $managedRoot -Processes $processes -Visited $managedVisited -Ordered $managedOrdered
+  }
+
+  $listenerPids = @($listeners | ForEach-Object { [int]$_.OwningProcess } | Sort-Object -Unique)
+  $unmanagedListenerPids = @($listenerPids | Where-Object { -not $managedVisited.Contains([int]$_) })
+  $recordedPid = $null
+  $recordedPidStale = $false
+  if (Test-Path -LiteralPath $script:PidMarkerPath) {
+    try {
+      $recordedText = Get-Content -LiteralPath $script:PidMarkerPath -Raw -Encoding UTF8
+      $parsedRecordedPid = 0
+      if ([int]::TryParse($recordedText.Trim(), [ref]$parsedRecordedPid) -and $parsedRecordedPid -gt 0) {
+        $recordedPid = $parsedRecordedPid
+        $recordedPidStale = -not $managedVisited.Contains($parsedRecordedPid)
+      } else {
+        $recordedPidStale = $true
+      }
+    } catch {
+      $recordedPidStale = $true
+    }
+  }
+
+  return [pscustomobject][ordered]@{
+    health = Get-HealthFact -ServicePort $Port
+    process = [pscustomobject][ordered]@{
+      pidMarkerPath = $script:PidMarkerPath
+      recordedPid = $recordedPid
+      recordedPidStale = $recordedPidStale
+      managedPids = @($managedOrdered | Sort-Object -Unique)
+      listenerPids = @($listenerPids)
+      unmanagedListenerPids = @($unmanagedListenerPids)
+    }
+    launcher = [pscustomobject][ordered]@{
+      path = $script:ResolvedLauncherPath
+      exists = Test-Path -LiteralPath $script:ResolvedLauncherPath -PathType Leaf
+    }
+    config = [pscustomobject][ordered]@{
+      path = $script:ResolvedConfigPath
+      exists = Test-Path -LiteralPath $script:ResolvedConfigPath -PathType Leaf
+    }
+    startupTask = Get-TaskFact -Name $TaskName
+    watchdogTask = Get-TaskFact -Name $WatchdogTaskName
+    processes = $processes
+  }
+}
+
+function Assert-NoUnmanagedListener {
+  param([object]$Snapshot)
+  $conflicts = @($Snapshot.process.unmanagedListenerPids)
+  if ($conflicts.Count -gt 0) {
+    throw (New-ServiceFailure -Code "UNMANAGED_PORT_CONFLICT" -Message "Port $Port is owned by unmanaged process PID(s): $($conflicts -join ', ').")
+  }
+}
+
+function Assert-RecoveryTasksExist {
+  param([object]$Snapshot)
+  $missing = @(
+    @($Snapshot.startupTask, $Snapshot.watchdogTask) |
+      Where-Object { -not $_.exists } |
+      ForEach-Object { $_.name }
+  )
+  if ($missing.Count -gt 0) {
+    throw (New-ServiceFailure -Code "MISSING_INSTALL_RESOURCE" -Message "Scheduled task(s) not found: $($missing -join ', ').")
+  }
+}
+
+function Set-TaskEnabledState {
+  param(
+    [object]$Task,
+    [bool]$Enabled
+  )
+  if ([bool]$Task.enabled -eq $Enabled) {
+    return
+  }
+  try {
+    $scheduledTask = Get-ExactScheduledTask -Name $Task.name
+    if (-not $scheduledTask) {
+      throw (New-ServiceFailure -Code "MISSING_INSTALL_RESOURCE" -Message "Scheduled task '$($Task.name)' no longer exists.")
+    }
+    if ($Enabled) {
+      Enable-ScheduledTask -InputObject $scheduledTask -ErrorAction Stop | Out-Null
+    } else {
+      Disable-ScheduledTask -InputObject $scheduledTask -ErrorAction Stop | Out-Null
+    }
+  } catch {
+    $serviceCode = [string]$_.Exception.Data["ServiceCode"]
+    if (-not [string]::IsNullOrWhiteSpace($serviceCode)) {
+      throw
+    }
+    throw (New-ServiceFailure -Code "PROCESS_CONTROL_FAILED" -Message "Could not set scheduled task '$($Task.name)' enabled=$Enabled.")
+  }
+}
+
+function Stop-ManagedProcessTree {
+  param([object]$Snapshot)
+  $visited = New-Object 'System.Collections.Generic.HashSet[int]'
+  $ordered = New-Object 'System.Collections.Generic.List[int]'
+  foreach ($managedPid in @($Snapshot.process.managedPids)) {
+    Add-ProcessTreePostOrder -RootProcessId ([int]$managedPid) -Processes $Snapshot.processes -Visited $visited -Ordered $ordered
+  }
+  foreach ($managedPid in $ordered) {
+    try {
+      Stop-Process -Id $managedPid -Force -ErrorAction SilentlyContinue
+    } catch {
+      throw (New-ServiceFailure -Code "PROCESS_CONTROL_FAILED" -Message "Could not stop managed process PID $managedPid.")
+    }
+  }
+  if ($ordered.Count -eq 0) {
+    return
+  }
+  $deadline = (Get-Date).AddSeconds(10)
+  do {
+    $remaining = @($ordered | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
+    if ($remaining.Count -eq 0) {
+      return
+    }
+    Start-Sleep -Milliseconds 100
+  } while ((Get-Date) -lt $deadline)
+  throw (New-ServiceFailure -Code "PROCESS_CONTROL_FAILED" -Message "Managed process PID(s) did not exit: $($remaining -join ', ').")
+}
+
+function Start-ManagedLauncher {
+  $launcherArgument = '"{0}"' -f $script:ResolvedLauncherPath.Replace('"', '""')
+  try {
+    Start-Process `
+      -FilePath "cmd.exe" `
+      -ArgumentList @("/d", "/s", "/c", $launcherArgument) `
+      -WorkingDirectory (Split-Path -Parent $script:ResolvedLauncherPath) `
+      -WindowStyle Hidden | Out-Null
+  } catch {
+    throw (New-ServiceFailure -Code "PROCESS_CONTROL_FAILED" -Message "Could not start the managed launcher.")
+  }
+}
+
+function Wait-ServiceHealth {
+  $deadline = (Get-Date).AddSeconds($HealthTimeoutSeconds)
+  do {
+    $health = Get-HealthFact -ServicePort $Port
+    if ($health.ready) {
+      return
+    }
+    Start-Sleep -Milliseconds 250
+  } while ((Get-Date) -lt $deadline)
+  throw (New-ServiceFailure -Code "HEALTH_TIMEOUT" -Message "Service health did not become ready within $HealthTimeoutSeconds second(s).")
+}
+
+function New-ServiceResult {
+  param(
+    [bool]$Ok,
+    [string]$Code,
+    [string]$Message,
+    [object]$Snapshot
+  )
+  return [pscustomobject][ordered]@{
+    ok = $Ok
+    action = $Action
+    code = $Code
+    message = $Message
+    port = $Port
+    health = $Snapshot.health
+    process = $Snapshot.process
+    launcher = $Snapshot.launcher
+    config = $Snapshot.config
+    startupTask = $Snapshot.startupTask
+    watchdogTask = $Snapshot.watchdogTask
+  }
+}
+
+function Write-ServiceResult {
+  param([object]$Result)
+  if ($OutputFormat -eq "Json") {
+    $Result | ConvertTo-Json -Depth 8 -Compress | Write-Output
+    return
+  }
+  $managedPids = if (@($Result.process.managedPids).Count -gt 0) { @($Result.process.managedPids) -join ", " } else { "none" }
+  $listenerPids = if (@($Result.process.listenerPids).Count -gt 0) { @($Result.process.listenerPids) -join ", " } else { "none" }
+  Write-Host "$($Result.action): $($Result.message)"
+  Write-Host "Health: $($Result.health.ready) ($($Result.health.url))"
+  Write-Host "Managed PIDs: $managedPids"
+  Write-Host "Listener PIDs: $listenerPids"
+  Write-Host "Config: exists=$($Result.config.exists) path=$($Result.config.path)"
+  Write-Host "Launcher: exists=$($Result.launcher.exists) path=$($Result.launcher.path)"
+  Write-Host "Startup task: exists=$($Result.startupTask.exists) enabled=$($Result.startupTask.enabled) state=$($Result.startupTask.state)"
+  Write-Host "Watchdog task: exists=$($Result.watchdogTask.exists) enabled=$($Result.watchdogTask.enabled) state=$($Result.watchdogTask.state)"
+  if (-not $Result.ok) {
+    Write-Host "Error code: $($Result.code)" -ForegroundColor Red
+    if (@($Result.process.unmanagedListenerPids).Count -gt 0) {
+      Write-Host "Unmanaged listener PIDs: $(@($Result.process.unmanagedListenerPids) -join ', ')" -ForegroundColor Red
+    }
+  }
+}
+
+function New-FallbackSnapshot {
+  return [pscustomobject][ordered]@{
+    health = Get-HealthFact -ServicePort $Port
+    process = [pscustomobject][ordered]@{
+      pidMarkerPath = $script:PidMarkerPath
+      recordedPid = $null
+      recordedPidStale = $false
+      managedPids = @()
+      listenerPids = @()
+      unmanagedListenerPids = @()
+    }
+    launcher = [pscustomobject][ordered]@{
+      path = $script:ResolvedLauncherPath
+      exists = Test-Path -LiteralPath $script:ResolvedLauncherPath -PathType Leaf
+    }
+    config = [pscustomobject][ordered]@{
+      path = $script:ResolvedConfigPath
+      exists = Test-Path -LiteralPath $script:ResolvedConfigPath -PathType Leaf
+    }
+    startupTask = [pscustomobject][ordered]@{ name = $TaskName; exists = $false; enabled = $false; state = "Unknown" }
+    watchdogTask = [pscustomobject][ordered]@{ name = $WatchdogTaskName; exists = $false; enabled = $false; state = "Unknown" }
+  }
+}
+
+$script:ResolvedConfigPath = Get-NormalizedPath -Path $ConfigPath -Label "Config path"
+$script:ResolvedLauncherPath = Get-NormalizedPath -Path $LauncherPath -Label "Launcher path"
+$configDirectory = Split-Path -Parent $script:ResolvedConfigPath
+$script:PidMarkerPath = Join-Path $configDirectory "cx-codex-$Port.pid"
+$script:ManagedIdentityPaths = @($script:ResolvedConfigPath, $script:ResolvedLauncherPath)
+
+$requiredCommands = @("Get-CimInstance", "Get-NetTCPConnection", "Get-ScheduledTask")
+foreach ($requiredCommand in $requiredCommands) {
+  if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+    $snapshot = New-FallbackSnapshot
+    $result = New-ServiceResult `
+      -Ok $false `
+      -Code "SYSTEM_INSPECTION_FAILED" `
+      -Message "Required Windows command '$requiredCommand' is unavailable." `
+      -Snapshot $snapshot
+    Write-ServiceResult -Result $result
+    exit $script:ExitCodes.SYSTEM_INSPECTION_FAILED
+  }
+}
+
+$lastSnapshot = $null
+try {
+  $lastSnapshot = Get-ServiceSnapshot
+  if ($Action -eq "status") {
+    Write-ServiceResult -Result (New-ServiceResult -Ok $true -Code "OK" -Message "Service status collected." -Snapshot $lastSnapshot)
+    exit 0
+  }
+
+  if ($Action -eq "disable") {
+    Assert-RecoveryTasksExist -Snapshot $lastSnapshot
+    Set-TaskEnabledState -Task $lastSnapshot.watchdogTask -Enabled $false
+    Set-TaskEnabledState -Task $lastSnapshot.startupTask -Enabled $false
+    $lastSnapshot = Get-ServiceSnapshot
+    Write-ServiceResult -Result (New-ServiceResult -Ok $true -Code "OK" -Message "Startup recovery disabled." -Snapshot $lastSnapshot)
+    exit 0
+  }
+
+  if ($Action -eq "enable") {
+    Assert-RecoveryTasksExist -Snapshot $lastSnapshot
+    Set-TaskEnabledState -Task $lastSnapshot.startupTask -Enabled $true
+    Set-TaskEnabledState -Task $lastSnapshot.watchdogTask -Enabled $true
+    $lastSnapshot = Get-ServiceSnapshot
+    Write-ServiceResult -Result (New-ServiceResult -Ok $true -Code "OK" -Message "Startup recovery enabled." -Snapshot $lastSnapshot)
+    exit 0
+  }
+
+  Assert-NoUnmanagedListener -Snapshot $lastSnapshot
+  if ($Action -eq "stop") {
+    Stop-ManagedProcessTree -Snapshot $lastSnapshot
+    $lastSnapshot = Get-ServiceSnapshot
+    Write-ServiceResult -Result (New-ServiceResult -Ok $true -Code "OK" -Message "Managed service process stopped." -Snapshot $lastSnapshot)
+    exit 0
+  }
+
+  if (-not $lastSnapshot.config.exists) {
+    throw (New-ServiceFailure -Code "MISSING_INSTALL_RESOURCE" -Message "Managed config is missing.")
+  }
+  if (-not $lastSnapshot.launcher.exists) {
+    throw (New-ServiceFailure -Code "MISSING_INSTALL_RESOURCE" -Message "Managed launcher is missing.")
+  }
+
+  if ($Action -eq "start") {
+    if (-not $lastSnapshot.health.ready) {
+      Start-ManagedLauncher
+      Wait-ServiceHealth
+    }
+    $lastSnapshot = Get-ServiceSnapshot
+    Write-ServiceResult -Result (New-ServiceResult -Ok $true -Code "OK" -Message "Managed service process started." -Snapshot $lastSnapshot)
+    exit 0
+  }
+
+  Stop-ManagedProcessTree -Snapshot $lastSnapshot
+  Start-ManagedLauncher
+  Wait-ServiceHealth
+  $lastSnapshot = Get-ServiceSnapshot
+  Write-ServiceResult -Result (New-ServiceResult -Ok $true -Code "OK" -Message "Managed service process restarted." -Snapshot $lastSnapshot)
+  exit 0
+} catch {
+  $failure = $_
+  $code = [string]$failure.Exception.Data["ServiceCode"]
+  if ([string]::IsNullOrWhiteSpace($code) -or -not $script:ExitCodes.ContainsKey($code)) {
+    $code = "INTERNAL_ERROR"
+  }
+  $message = [string]$failure.Exception.Message
+  try {
+    $lastSnapshot = Get-ServiceSnapshot
+  } catch {
+    if (-not $lastSnapshot) {
+      $lastSnapshot = New-FallbackSnapshot
+    }
+  }
+  Write-ServiceResult -Result (New-ServiceResult -Ok $false -Code $code -Message $message -Snapshot $lastSnapshot)
+  exit $script:ExitCodes[$code]
+}

--- a/scripts/verify-release.ps1
+++ b/scripts/verify-release.ps1
@@ -447,7 +447,9 @@ if (-not $SkipPackageSmoke) {
     "LICENSE",
     "dist\index.html",
     "dist-cli\index.js",
-    "docs\app-server-schema-audit-summary.json"
+    "docs\app-server-schema-audit-summary.json",
+    "scripts\run-powershell-script.mjs",
+    "scripts\manage-windows-service.ps1"
   ) -ForbiddenEntries @(
     "src\server\codexAppServerBridge.ts",
     "scripts\verify-release.ps1",

--- a/scripts/verify-windows-productization.ps1
+++ b/scripts/verify-windows-productization.ps1
@@ -87,12 +87,16 @@ $installScript = Join-Path $repoRoot "scripts\install-windows-server.ps1"
 $uninstallScript = Join-Path $repoRoot "scripts\uninstall-windows.ps1"
 $bootstrapScript = Join-Path $repoRoot "scripts\bootstrap-windows.ps1"
 $restartScript = Join-Path $repoRoot "scripts\restart-local-service.ps1"
+$serviceScript = Join-Path $repoRoot "scripts\manage-windows-service.ps1"
 $cliScript = Join-Path $repoRoot "src\cli\index.ts"
+$serviceAdapterScript = Join-Path $repoRoot "src\cli\windowsServiceCommand.ts"
 $testRoot = Join-Path $env:TEMP "cx-codex-productization-$PID"
 $installSource = Get-Content -LiteralPath $installScript -Raw
 $bootstrapSource = Get-Content -LiteralPath $bootstrapScript -Raw
 $restartSource = Get-Content -LiteralPath $restartScript -Raw
+$serviceSource = Get-Content -LiteralPath $serviceScript -Raw
 $cliSource = Get-Content -LiteralPath $cliScript -Raw
+$serviceAdapterSource = Get-Content -LiteralPath $serviceAdapterScript -Raw
 Assert-True `
   ($installSource -match "function\s+Wait-ForTunnelReadyState") `
   "Windows installer must wait for the runtime tunnel readiness state."
@@ -123,6 +127,18 @@ Assert-True `
 Assert-True `
   ($cliSource -match 'function\s+listenOnRequestedPort[\s\S]*?will not silently start a second broker[\s\S]*?server\.listen\(port,\s*host\)' -and $cliSource -notmatch 'attempt\(port\s*\+\s*1\)') `
   "CLI port conflicts must fail explicitly instead of starting a second broker on another port."
+Assert-True `
+  ($cliSource -match "'start'[\s\S]*?'stop'[\s\S]*?'restart'[\s\S]*?'status'[\s\S]*?'enable'[\s\S]*?'disable'" -and $serviceAdapterSource -match "WindowsServiceAction = 'start' \| 'stop' \| 'restart' \| 'status' \| 'enable' \| 'disable'") `
+  "Windows service CLI must expose the complete process and recovery-task action set."
+Assert-True `
+  ($serviceSource -match 'if \(\$Action -eq "stop"\)[\s\S]*?Stop-ManagedProcessTree' -and $serviceSource -notmatch 'if \(\$Action -eq "stop"\)[\s\S]*?Set-TaskEnabledState') `
+  "Windows service stop must control only the managed process tree."
+Assert-True `
+  ($serviceSource -match 'if \(\$Action -eq "disable"\)[\s\S]*?Set-TaskEnabledState[\s\S]*?if \(\$Action -eq "enable"\)[\s\S]*?Set-TaskEnabledState') `
+  "Windows service enable and disable must own scheduled-task state changes."
+Assert-True `
+  ($serviceSource -match 'UNMANAGED_PORT_CONFLICT' -and $serviceSource -match 'Add-ProcessTreePostOrder' -and $serviceAdapterSource -match 'scriptsDirectory') `
+  "Windows service management must protect unmanaged listeners, stop child-first, and resolve packaged scripts."
 Assert-True `
   ($bootstrapSource -match 'function\s+Get-Sha256Hex[\s\S]*?Get-Command\s+Get-FileHash[\s\S]*?\[System\.Security\.Cryptography\.SHA256\]::Create\(\)') `
   "Windows bootstrap must fall back to .NET SHA-256 when Get-FileHash is unavailable."

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,13 @@ import {
 } from '../server/quickTunnel.js'
 import { startStableAccess } from '../server/tailscaleFunnel.js'
 import { spawnSyncCommand } from '../utils/commandInvocation.js'
+import {
+  getDefaultWindowsServiceConfigPath,
+  getDefaultWindowsServiceLauncherPath,
+  runWindowsServiceCommand,
+  type WindowsServiceAction,
+  type WindowsServiceCliOptions,
+} from './windowsServiceCommand.js'
 
 const program = new Command().name('cx-codex').description('CX-Codex Web bridge for Codex app-server')
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -641,6 +648,54 @@ program
   .description('Compact the runtime replay database while CX-Codex is stopped')
   .option('--database <path>', 'override the runtime database path')
   .action(runRuntimeCompact)
+
+const serviceCommand = program
+  .command('service')
+  .description('Manage the installed CX-Codex Windows service')
+
+function addWindowsServiceOptions(command: Command): Command {
+  return command
+    .option('--port <number>', 'managed service port', '7420')
+    .option('--config <path>', 'managed service config path', getDefaultWindowsServiceConfigPath())
+    .option('--launcher <path>', 'managed service launcher path', getDefaultWindowsServiceLauncherPath())
+    .option('--task-name <name>', 'startup scheduled task name')
+    .option('--watchdog-task-name <name>', 'watchdog scheduled task name')
+    .option('--json', 'output a single JSON object')
+}
+
+function getServiceRawOptionValue(
+  action: WindowsServiceAction,
+  optionName: '--port' | '--config',
+): string | undefined {
+  const rawArgs = process.argv.slice(2)
+  const actionIndex = rawArgs.findIndex((value, index) => value === action && rawArgs[index - 1] === 'service')
+  if (actionIndex < 0) return undefined
+  for (let index = actionIndex + 1; index < rawArgs.length; index += 1) {
+    const value = rawArgs[index]
+    if (value === optionName) return rawArgs[index + 1]
+    if (value.startsWith(`${optionName}=`)) return value.slice(optionName.length + 1)
+  }
+  return undefined
+}
+
+for (const [action, description] of [
+  ['start', 'Start the managed service process'],
+  ['stop', 'Stop the managed service process'],
+  ['restart', 'Restart the managed service process'],
+  ['status', 'Inspect managed service, process, listener, and task state'],
+  ['enable', 'Enable startup and watchdog recovery tasks'],
+  ['disable', 'Disable startup and watchdog recovery tasks'],
+] as const) {
+  addWindowsServiceOptions(serviceCommand.command(action).description(description))
+    .action((options: WindowsServiceCliOptions) => {
+      const serviceOptions = {
+        ...options,
+        port: getServiceRawOptionValue(action, '--port') ?? options.port,
+        config: getServiceRawOptionValue(action, '--config') ?? options.config,
+      }
+      process.exitCode = runWindowsServiceCommand(action, serviceOptions)
+    })
+}
 
 program.command('help').description('Show CX-Codex command help').action(() => {
   program.outputHelp()

--- a/src/cli/windowsServiceCommand.ts
+++ b/src/cli/windowsServiceCommand.ts
@@ -1,0 +1,166 @@
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSyncCommand } from '../utils/commandInvocation.js'
+
+export type WindowsServiceAction = 'start' | 'stop' | 'restart' | 'status' | 'enable' | 'disable'
+
+export interface WindowsServiceCliOptions {
+  port: string
+  config: string
+  launcher: string
+  taskName?: string
+  watchdogTaskName?: string
+  json?: boolean
+}
+
+interface ServiceCommandError {
+  code: 'INVALID_ARGUMENT' | 'UNSUPPORTED_PLATFORM' | 'MISSING_INSTALL_RESOURCE' | 'INTERNAL_ERROR'
+  exitCode: 1 | 2 | 3 | 4
+  message: string
+}
+
+const SERVICE_SCRIPT_NAME = 'manage-windows-service.ps1'
+const POWERSHELL_RUNNER_NAME = 'run-powershell-script.mjs'
+
+export function getDefaultWindowsServiceConfigPath(): string {
+  return join(homedir(), '.cx-codex', 'config.json')
+}
+
+export function getDefaultWindowsServiceLauncherPath(): string {
+  return join(homedir(), '.local', 'bin', 'cx-codex-start.cmd')
+}
+
+function writeAdapterError(
+  action: WindowsServiceAction,
+  port: number | null,
+  options: WindowsServiceCliOptions,
+  error: ServiceCommandError,
+  json: boolean,
+): void {
+  if (json) {
+    const taskName = options.taskName?.trim() || (port === null ? null : `CodexUI-${port}`)
+    const watchdogTaskName = options.watchdogTaskName?.trim() || (port === null ? null : `CodexUI-${port}-Watchdog`)
+    console.log(JSON.stringify({
+      ok: false,
+      action,
+      code: error.code,
+      message: error.message,
+      port,
+      health: { ready: false, url: port === null ? null : `http://127.0.0.1:${port}/health` },
+      process: {
+        pidMarkerPath: null,
+        recordedPid: null,
+        recordedPidStale: false,
+        managedPids: [],
+        listenerPids: [],
+        unmanagedListenerPids: [],
+      },
+      launcher: { path: options.launcher?.trim() || null, exists: false },
+      config: { path: options.config?.trim() || null, exists: false },
+      startupTask: { name: taskName, exists: false, enabled: false, state: 'Unknown' },
+      watchdogTask: { name: watchdogTaskName, exists: false, enabled: false, state: 'Unknown' },
+    }))
+    return
+  }
+  console.error(`[${error.code}] ${error.message}`)
+}
+
+function fail(
+  action: WindowsServiceAction,
+  port: number | null,
+  options: WindowsServiceCliOptions,
+  error: ServiceCommandError,
+  json: boolean,
+): number {
+  writeAdapterError(action, port, options, error, json)
+  return error.exitCode
+}
+
+function requireNonBlank(value: string | undefined, label: string): string {
+  const normalized = value?.trim() ?? ''
+  if (!normalized) throw new Error(`${label} must not be empty.`)
+  return normalized
+}
+
+function resolveServiceScriptsDirectory(): string | null {
+  const cliDirectory = dirname(fileURLToPath(import.meta.url))
+  const candidates = [
+    resolve(cliDirectory, '..', 'scripts'),
+    resolve(process.cwd(), 'scripts'),
+  ]
+  for (const scriptsDirectory of [...new Set(candidates)]) {
+    const runnerPath = join(scriptsDirectory, POWERSHELL_RUNNER_NAME)
+    const serviceScriptPath = join(scriptsDirectory, SERVICE_SCRIPT_NAME)
+    if (existsSync(runnerPath) && existsSync(serviceScriptPath)) return scriptsDirectory
+  }
+  return null
+}
+
+export function runWindowsServiceCommand(action: WindowsServiceAction, options: WindowsServiceCliOptions): number {
+  const json = options.json === true
+  const parsedPort = Number(options.port)
+  if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65_535) {
+    return fail(action, null, options, {
+      code: 'INVALID_ARGUMENT',
+      exitCode: 2,
+      message: 'Port must be an integer between 1 and 65535.',
+    }, json)
+  }
+
+  let configPath: string
+  let launcherPath: string
+  let taskName: string
+  let watchdogTaskName: string
+  try {
+    configPath = resolve(requireNonBlank(options.config, 'Config path'))
+    launcherPath = resolve(requireNonBlank(options.launcher, 'Launcher path'))
+    taskName = requireNonBlank(options.taskName ?? `CodexUI-${parsedPort}`, 'Task name')
+    watchdogTaskName = requireNonBlank(options.watchdogTaskName ?? `CodexUI-${parsedPort}-Watchdog`, 'Watchdog task name')
+  } catch (error) {
+    return fail(action, parsedPort, options, {
+      code: 'INVALID_ARGUMENT',
+      exitCode: 2,
+      message: error instanceof Error ? error.message : String(error),
+    }, json)
+  }
+
+  if (process.platform !== 'win32') {
+    return fail(action, parsedPort, options, {
+      code: 'UNSUPPORTED_PLATFORM',
+      exitCode: 3,
+      message: 'Windows service management is only available on Windows.',
+    }, json)
+  }
+
+  const scriptsDirectory = resolveServiceScriptsDirectory()
+  if (!scriptsDirectory) {
+    return fail(action, parsedPort, options, {
+      code: 'MISSING_INSTALL_RESOURCE',
+      exitCode: 4,
+      message: `Could not locate ${POWERSHELL_RUNNER_NAME} and ${SERVICE_SCRIPT_NAME} in the same scripts directory.`,
+    }, json)
+  }
+
+  const result = spawnSyncCommand(process.execPath, [
+    join(scriptsDirectory, POWERSHELL_RUNNER_NAME),
+    join(scriptsDirectory, SERVICE_SCRIPT_NAME),
+    '-Action', action,
+    '-Port', String(parsedPort),
+    '-ConfigPath', configPath,
+    '-LauncherPath', launcherPath,
+    '-TaskName', taskName,
+    '-WatchdogTaskName', watchdogTaskName,
+    '-OutputFormat', json ? 'Json' : 'Human',
+  ], { stdio: 'inherit', windowsHide: true })
+
+  if (result.error) {
+    return fail(action, parsedPort, options, {
+      code: 'INTERNAL_ERROR',
+      exitCode: 1,
+      message: result.error.message,
+    }, json)
+  }
+  return result.status ?? 1
+}

--- a/tests.md
+++ b/tests.md
@@ -15887,3 +15887,18 @@ Current evidence:
 - The foreground restart-policy test failed before the fix because a selected idle conversation forced a restart; it passes after requiring actual sync demand for a connected stale stream.
 - The full 38-surface regression passed in 499.7 seconds. The built-in stress probe mounted 13 of 1602 messages with 64ms maximum lag and accepted interaction while output continued.
 - Independent headless Playwright mounted 12 of 1602 messages with 47ms maximum lag; the action count increased by one, updates continued from 76 to 84, and console/request failure lists were empty.
+
+## Windows 服务管理 CLI
+
+1. `cx-codex service start|stop|restart|status|enable|disable` 必须接受 `--port`、`--config`、`--launcher`、`--task-name`、`--watchdog-task-name` 和 `--json`，且不得改变根服务命令的既有参数。
+2. `start`、`stop` 和 `restart` 只管理与显式配置或 launcher 匹配的进程树；`stop` 不禁用任务，`start` 不启用任务，`restart` 不改变任何任务状态。
+3. `enable` 和 `disable` 只修改已存在的登录启动与 watchdog 任务，不启动或停止服务进程；任务名必须精确匹配。
+4. `status` 只读；服务未运行、资源缺失或 PID 标记过期应作为状态返回。非托管进程占用目标端口时，进程控制命令必须以稳定错误码拒绝操作。
+5. `--json` 成功和失败均只输出一个结构稳定的 JSON 对象；npm 包必须显式包含 PowerShell 运行器和服务管理脚本。
+
+Verification:
+
+- Run `npm.cmd run build:cli` and inspect `cx-codex service --help` plus each subcommand help entry.
+- Run `npm.cmd run verify:windows-productization` without changing the machine's real CX-Codex service or scheduled tasks.
+- Run `npm.cmd run verify:release -- -SkipBuild -SkipCliSmoke` after existing build output is available and confirm npm package smoke includes only the two required runtime scripts.
+- Parse `scripts/manage-windows-service.ps1`, confirm changed files are UTF-8 without BOM, and inspect `git diff --check`.


### PR DESCRIPTION
## 变更说明

- 新增 `cx-codex service start|stop|restart|status|enable|disable`
- 将进程启停与计划任务启禁解耦，避免 `start/stop/restart` 隐式改变任务状态
- 只管理与明确配置或 launcher 匹配的 CX-Codex 进程；目标端口被非托管进程占用时拒绝操作
- 提供稳定的人类可读输出、单对象 JSON 输出和明确退出码
- 将 PowerShell 管理脚本及运行器纳入 npm 包和 Release 验证清单

## 验证结果

- [x] `npm.cmd run build:cli`
- [x] `npm.cmd run verify:windows-productization`
- [x] `npm.cmd run verify:release -- -SkipBuild -SkipCliSmoke`
- [x] 根命令、`service` 命令及六个子命令帮助 smoke
- [x] `service status --json`、PowerShell 语法、UTF-8/BOM 和 `git diff --check`
- [ ] 单元测试（按本次工作约束未运行）

## 隐私与安全

- [x] 不包含密码、Token、Cookie、私有 IP、真实公网地址或个人目录
- [x] 不写死个人配置、私人服务器地址或本地路径
- [x] 服务管理限制在 Windows 本机已识别的进程、端口和精确任务名称范围内