### PR TITLE
fix(release): 校验 Release ZIP 运行时完整性

### DIFF
--- a/scripts/verify-release-artifacts.ps1
+++ b/scripts/verify-release-artifacts.ps1
@@ -92,6 +92,76 @@ function Assert-ArtifactHasChecksum {
   throw "Release artifact is missing checksum: $($Artifact.Name)"
 }
 
+function Assert-ZipContainsRuntimeContract {
+  param(
+    [System.IO.FileInfo]$Artifact
+  )
+
+  $archive = [System.IO.Compression.ZipFile]::OpenRead($Artifact.FullName)
+  try {
+    $entryNames = [System.Collections.Generic.HashSet[string]]::new(
+      [System.StringComparer]::Ordinal
+    )
+    foreach ($entry in $archive.Entries) {
+      $normalizedName = $entry.FullName.Replace("\", "/").TrimStart([char]"/")
+      [void]$entryNames.Add($normalizedName)
+    }
+
+    $requiredEntries = @(
+      "package.json",
+      "vite.config.ts",
+      "vite.local-preview.config.ts"
+    )
+    foreach ($requiredEntry in $requiredEntries) {
+      if (-not $entryNames.Contains($requiredEntry)) {
+        throw "Release zip is missing required entry: $requiredEntry ($($Artifact.Name))"
+      }
+    }
+
+    $packageEntry = $archive.GetEntry("package.json")
+    $packageStream = $packageEntry.Open()
+    try {
+      $reader = [System.IO.StreamReader]::new(
+        $packageStream,
+        [System.Text.UTF8Encoding]::new($false, $true),
+        $true
+      )
+      try {
+        $packageManifest = $reader.ReadToEnd() | ConvertFrom-Json
+      } finally {
+        $reader.Dispose()
+      }
+    } finally {
+      $packageStream.Dispose()
+    }
+
+    foreach ($packageFile in @($packageManifest.files)) {
+      $normalizedPackageFile = ([string]$packageFile).Replace("\", "/").TrimStart([char]"/")
+      if ([string]::IsNullOrWhiteSpace($normalizedPackageFile)) {
+        throw "Release zip package.json contains an empty files entry: $($Artifact.Name)"
+      }
+      if ($normalizedPackageFile.EndsWith("/", [System.StringComparison]::Ordinal)) {
+        $hasDirectoryContent = $false
+        foreach ($entryName in $entryNames) {
+          if ($entryName.StartsWith($normalizedPackageFile, [System.StringComparison]::Ordinal)) {
+            $hasDirectoryContent = $true
+            break
+          }
+        }
+        if (-not $hasDirectoryContent) {
+          throw "Release zip is missing npm package directory: $normalizedPackageFile ($($Artifact.Name))"
+        }
+      } elseif (-not $entryNames.Contains($normalizedPackageFile)) {
+        throw "Release zip is missing npm package entry: $normalizedPackageFile ($($Artifact.Name))"
+      }
+    }
+  } finally {
+    $archive.Dispose()
+  }
+
+  Write-Host "zip runtime contract ok: $($Artifact.Name)"
+}
+
 $resolvedOutputDir = (Resolve-Path -LiteralPath $OutputDir).Path
 $releaseArtifacts = @(Get-ChildItem -LiteralPath $resolvedOutputDir -File | Where-Object {
   $_.Extension -in @(".zip", ".apk")
@@ -100,8 +170,13 @@ if ($releaseArtifacts.Count -eq 0) {
   throw "No release .zip or .apk artifacts found in $resolvedOutputDir"
 }
 
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 foreach ($artifact in $releaseArtifacts) {
   Assert-ArtifactHasChecksum -Artifact $artifact
+  if ($artifact.Extension -eq ".zip") {
+    Assert-ZipContainsRuntimeContract -Artifact $artifact
+  }
 }
 
 $checksumFiles = @(Get-ChildItem -LiteralPath $resolvedOutputDir -Filter "*.sha256" -File)

--- a/tests.md
+++ b/tests.md
@@ -15801,6 +15801,19 @@ Current evidence:
 - The local Android delivery build uses version `2.7.5` / code `20705`, bundles the same frontend `index.html` hash as `dist`, passes release signature and zip-alignment verification, and matches the signing certificate of the public `v2.7.4` APK so it can be installed as an in-place upgrade.
 - No Android device was connected during implementation, so physical process-death verification is still required before publishing an APK.
 
+## Release ZIP 运行时完整性校验
+
+1. `verify-release-artifacts.ps1` 必须直接打开每个 Release ZIP，不能只验证外部 SHA-256 文件。
+2. ZIP 必须包含 `package.json`、`vite.config.ts` 和 `vite.local-preview.config.ts`。
+3. ZIP 内 `package.json.files` 声明的每个文件必须精确存在；声明的每个目录必须至少包含一个条目。
+4. APK 继续只执行 checksum 验证，不按 ZIP 结构解析。
+
+Verification:
+
+- 生成本地 Release smoke 构件后运行 `npm.cmd run verify:release-artifacts -- -OutputDir <目录>`，确认 checksum 和 ZIP 运行时契约均通过。
+- 从 ZIP 中移除一个必需配置、npm 文件或 npm 目录内容，重新生成匹配 checksum，确认校验器仍以稳定的缺失条目信息失败。
+- 解析 PowerShell 脚本，检查 UTF-8 无 BOM，并运行 `git diff --check`。
+
 ## CX-Codex 2.7.4 release-package completeness (2026-08-04)
 
 1. `scripts/package-release.ps1` must treat both `vite.config.ts` and `vite.local-preview.config.ts` as required Release ZIP inputs because `npm run build:frontend` executes both configurations.


### PR DESCRIPTION
## 变更说明

- 在 checksum 验证之外直接打开每个 Release ZIP 并检查运行时契约
- 要求 ZIP 包含 `package.json`、`vite.config.ts` 和 `vite.local-preview.config.ts`
- 以严格 UTF-8 解析 ZIP 内的 `package.json`
- 校验 `package.json.files` 声明的文件精确存在，目录至少包含一个条目
- APK 保持原有 checksum 验证，不按 ZIP 结构解析

## 验证结果

- [x] `npm.cmd run verify:release-artifacts -- -OutputDir output\release-package-smoke`
- [x] ZIP 和 npm 运行时文件缺失负向 smoke
- [x] PowerShell 语法解析、UTF-8/BOM 检查和 `git diff --check`
- [ ] `npm run build`（使用既有构建产物执行构件验证）
- [ ] 单元测试（按本次工作约束未运行）

## 隐私与安全

- [x] 不包含密码、Token、Cookie、私有 IP、真实公网地址或个人目录
- [x] 不写死个人配置、私人服务器地址或本地路径
- [x] 不新增远程访问能力