### PR TITLE
fix(security): preserve upload path canonicalization

### DIFF
--- a/scripts/server-module-smoke.ts
+++ b/scripts/server-module-smoke.ts
@@ -5081,9 +5081,11 @@ async function smokeSessionAttachmentAccess(): Promise<void> {
 
 async function smokeUploadedLocalFileRoutes(): Promise<void> {
   const uploadRoot = await mkdtemp(join(tmpdir(), 'cx-codex-http-upload-'))
-  const uploadDir = join(uploadRoot, 'f-route')
+  const uploadDir = join(uploadRoot, 'f-route1')
   const imagePath = join(uploadDir, 'preview.png')
   const textPath = join(uploadDir, 'note.txt')
+  const internalCacheDir = join(uploadRoot, '_session-attachments')
+  const internalCachePath = join(internalCacheDir, 'private.txt')
   const outsideDir = await mkdtemp(join(tmpdir(), 'cx-codex-http-upload-outside-'))
   const outsidePath = join(outsideDir, 'secret.png')
   const clipboardPath = join(outsideDir, 'codex-clipboard-c574ffab-0033-4dbd-aef7-09267e4e7a30.jpg')
@@ -5096,6 +5098,8 @@ async function smokeUploadedLocalFileRoutes(): Promise<void> {
   await mkdir(uploadDir, { recursive: true })
   await writeFile(imagePath, pngBytes)
   await writeFile(textPath, 'uploaded note', 'utf8')
+  await mkdir(internalCacheDir, { recursive: true })
+  await writeFile(internalCachePath, 'internal cache', 'utf8')
   await writeFile(outsidePath, pngBytes)
   await writeFile(clipboardPath, pngBytes)
   await symlink(outsideDir, escapedLink, 'junction')
@@ -5125,7 +5129,6 @@ async function smokeUploadedLocalFileRoutes(): Promise<void> {
     },
     resolveUploadedFilePath: (candidatePath: string) => resolveUploadedFilePath(candidatePath, {
       uploadDir: uploadRoot,
-      stat,
     }),
     resolveSessionAttachmentPath: (candidatePath: string) => sessionAttachmentStore.resolve(candidatePath),
     localFileRateLimit: { limit: 8, windowMs: 60_000 },
@@ -5188,12 +5191,16 @@ async function smokeUploadedLocalFileRoutes(): Promise<void> {
     assert.deepEqual(await rateLimitedResponse.json(), { error: '本地文件请求过于频繁，请稍后重试。' })
 
     await assert.rejects(
-      () => resolveUploadedFilePath(join(escapedLink, 'secret.png'), { uploadDir: uploadRoot, stat }),
+      () => resolveUploadedFilePath(join(escapedLink, 'secret.png'), { uploadDir: uploadRoot }),
       (error: unknown) => error instanceof UploadedFileAccessError && error.code === 'outside-upload-root',
     )
     await assert.rejects(
-      () => resolveUploadedFilePath(join(uploadDir, 'missing.png'), { uploadDir: uploadRoot, stat }),
+      () => resolveUploadedFilePath(join(uploadDir, 'missing.png'), { uploadDir: uploadRoot }),
       (error: unknown) => error instanceof UploadedFileAccessError && error.code === 'not-found',
+    )
+    await assert.rejects(
+      () => resolveUploadedFilePath(internalCachePath, { uploadDir: uploadRoot }),
+      (error: unknown) => error instanceof UploadedFileAccessError && error.code === 'outside-upload-root',
     )
   } finally {
     await new Promise<void>((resolve, reject) => {

--- a/scripts/server-module-smoke.ts
+++ b/scripts/server-module-smoke.ts
@@ -5125,7 +5125,6 @@ async function smokeUploadedLocalFileRoutes(): Promise<void> {
     },
     resolveUploadedFilePath: (candidatePath: string) => resolveUploadedFilePath(candidatePath, {
       uploadDir: uploadRoot,
-      realpath,
       stat,
     }),
     resolveSessionAttachmentPath: (candidatePath: string) => sessionAttachmentStore.resolve(candidatePath),
@@ -5189,11 +5188,11 @@ async function smokeUploadedLocalFileRoutes(): Promise<void> {
     assert.deepEqual(await rateLimitedResponse.json(), { error: '本地文件请求过于频繁，请稍后重试。' })
 
     await assert.rejects(
-      () => resolveUploadedFilePath(join(escapedLink, 'secret.png'), { uploadDir: uploadRoot, realpath, stat }),
+      () => resolveUploadedFilePath(join(escapedLink, 'secret.png'), { uploadDir: uploadRoot, stat }),
       (error: unknown) => error instanceof UploadedFileAccessError && error.code === 'outside-upload-root',
     )
     await assert.rejects(
-      () => resolveUploadedFilePath(join(uploadDir, 'missing.png'), { uploadDir: uploadRoot, realpath, stat }),
+      () => resolveUploadedFilePath(join(uploadDir, 'missing.png'), { uploadDir: uploadRoot, stat }),
       (error: unknown) => error instanceof UploadedFileAccessError && error.code === 'not-found',
     )
   } finally {

--- a/src/server/fileUpload.ts
+++ b/src/server/fileUpload.ts
@@ -38,7 +38,6 @@ export class UploadedFileAccessError extends Error {
 
 export type UploadedFileAccessDependencies = {
   uploadDir?: string
-  realpath?: typeof realpath
   stat?: typeof stat
 }
 
@@ -140,11 +139,10 @@ export async function resolveUploadedFilePath(
     throw new UploadedFileAccessError('outside-upload-root')
   }
 
-  const resolveRealPath = dependencies.realpath ?? realpath
   const readStat = dependencies.stat ?? stat
   let canonicalCandidate: string
   try {
-    canonicalCandidate = await resolveRealPath(normalizedCandidate)
+    canonicalCandidate = await realpath(normalizedCandidate)
   } catch {
     throw new UploadedFileAccessError('not-found')
   }
@@ -155,7 +153,7 @@ export async function resolveUploadedFilePath(
     if (!uploadRootStat.isDirectory()) {
       throw new UploadedFileAccessError('not-found')
     }
-    canonicalUploadRoot = await resolveRealPath(uploadRoot)
+    canonicalUploadRoot = await realpath(uploadRoot)
   } catch (error) {
     if (error instanceof UploadedFileAccessError) throw error
     throw new UploadedFileAccessError('not-found')

--- a/src/server/fileUpload.ts
+++ b/src/server/fileUpload.ts
@@ -1,7 +1,7 @@
-import { mkdir, mkdtemp, realpath, stat, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, realpath, writeFile } from 'node:fs/promises'
 import type { IncomingMessage } from 'node:http'
 import { tmpdir } from 'node:os'
-import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { RequestBodyTooLargeError, readRawBody } from './httpBody.js'
 
 export type ParsedMultipartFileUpload = {
@@ -10,6 +10,7 @@ export type ParsedMultipartFileUpload = {
 }
 
 const FILE_UPLOAD_REQUEST_BODY_LIMIT_BYTES = 50 * 1024 * 1024
+const GENERATED_UPLOAD_DIRECTORY_PATTERN = /^f-[A-Za-z0-9]{6}$/u
 
 export class FileUploadError extends Error {
   constructor(
@@ -38,7 +39,6 @@ export class UploadedFileAccessError extends Error {
 
 export type UploadedFileAccessDependencies = {
   uploadDir?: string
-  stat?: typeof stat
 }
 
 function readUploadEnv(name: string): string {
@@ -139,34 +139,55 @@ export async function resolveUploadedFilePath(
     throw new UploadedFileAccessError('outside-upload-root')
   }
 
-  const readStat = dependencies.stat ?? stat
-  let canonicalCandidate: string
-  try {
-    canonicalCandidate = await realpath(normalizedCandidate)
-  } catch {
-    throw new UploadedFileAccessError('not-found')
-  }
-
-  let canonicalUploadRoot: string
-  try {
-    const uploadRootStat = await readStat(uploadRoot)
-    if (!uploadRootStat.isDirectory()) {
-      throw new UploadedFileAccessError('not-found')
-    }
-    canonicalUploadRoot = await realpath(uploadRoot)
-  } catch (error) {
-    if (error instanceof UploadedFileAccessError) throw error
-    throw new UploadedFileAccessError('not-found')
-  }
-
+  const relativeCandidate = relative(uploadRoot, normalizedCandidate)
+  const pathSegments = relativeCandidate.split(sep)
+  const requestedDirectoryName = pathSegments[0] ?? ''
+  const requestedFileName = pathSegments[1] ?? ''
   if (
-    canonicalCandidate !== canonicalUploadRoot
-    && !canonicalCandidate.startsWith(`${canonicalUploadRoot}${sep}`)
+    (pathSegments.length !== 1 && pathSegments.length !== 2)
+    || !GENERATED_UPLOAD_DIRECTORY_PATTERN.test(requestedDirectoryName)
+    || (pathSegments.length === 2 && (
+      !requestedFileName
+      || basename(requestedFileName) !== requestedFileName
+    ))
   ) {
     throw new UploadedFileAccessError('outside-upload-root')
   }
 
-  return canonicalCandidate
+  try {
+    const canonicalUploadRoot = await realpath(uploadRoot)
+    const uploadDirectoryEntry = (await readdir(canonicalUploadRoot, { withFileTypes: true }))
+      .find((entry) => (
+        entry.isDirectory()
+        && !entry.isSymbolicLink()
+        && GENERATED_UPLOAD_DIRECTORY_PATTERN.test(entry.name)
+        && entry.name === requestedDirectoryName
+      ))
+    if (!uploadDirectoryEntry) throw new UploadedFileAccessError('not-found')
+
+    const canonicalUploadDirectory = await realpath(join(canonicalUploadRoot, uploadDirectoryEntry.name))
+    if (
+      canonicalUploadDirectory === canonicalUploadRoot
+      || !canonicalUploadDirectory.startsWith(`${canonicalUploadRoot}${sep}`)
+    ) {
+      throw new UploadedFileAccessError('outside-upload-root')
+    }
+    if (pathSegments.length === 1) return canonicalUploadDirectory
+
+    const fileEntry = (await readdir(canonicalUploadDirectory, { withFileTypes: true }))
+      .find((entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name === requestedFileName)
+    if (!fileEntry) throw new UploadedFileAccessError('not-found')
+
+    const canonicalCandidate = await realpath(join(canonicalUploadDirectory, fileEntry.name))
+    if (!canonicalCandidate.startsWith(`${canonicalUploadDirectory}${sep}`)) {
+      throw new UploadedFileAccessError('outside-upload-root')
+    }
+
+    return canonicalCandidate
+  } catch (error) {
+    if (error instanceof UploadedFileAccessError) throw error
+    throw new UploadedFileAccessError('not-found')
+  }
 }
 
 export async function readRequestBody(req: IncomingMessage, options: { maxBytes?: number } = {}): Promise<Buffer> {

--- a/src/server/fileUpload.ts
+++ b/src/server/fileUpload.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, realpath, stat, writeFile } from 'node:fs/promises'
 import type { IncomingMessage } from 'node:http'
 import { tmpdir } from 'node:os'
-import { isAbsolute, join, relative, resolve } from 'node:path'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { RequestBodyTooLargeError, readRawBody } from './httpBody.js'
 
 export type ParsedMultipartFileUpload = {
@@ -159,7 +159,10 @@ export async function resolveUploadedFilePath(
     throw new UploadedFileAccessError('not-found')
   }
 
-  if (!isPathWithinRoot(canonicalUploadRoot, canonicalCandidate)) {
+  if (
+    canonicalCandidate !== canonicalUploadRoot
+    && !canonicalCandidate.startsWith(`${canonicalUploadRoot}${sep}`)
+  ) {
     throw new UploadedFileAccessError('outside-upload-root')
   }
 

--- a/tests.md
+++ b/tests.md
@@ -14585,6 +14585,7 @@ Verification:
 
 - 复现探针确认真实上传图片文件存在，但旧 7420 对 `/codex-local-image?path=...codex-web-uploads...` 返回 `HTTP 403` 与“该路径不在已登记的工作区目录内”。
 - `npm.cmd run verify:server-modules` 覆盖上传缓存图片读取、直接文件读取、文件卡片 browse 预览、缓存目录拒绝、编辑拒绝、外部路径拒绝和 junction 逃逸拒绝。
+- 上传缓存路径直接使用 Node `realpath` 完成规范化后再校验 canonical 根目录，不允许通过可替换的路径解析函数绕过静态分析；发布 PR 的高危 `js/path-injection` CodeQL 门禁必须为零。
 - 隔离候选服务使用临时 Runtime DB 和无副作用 bridge；`agent-browser` 在 393 x 852 H5 视口打开真实上传路径，图片 `complete=true`、原始尺寸 `1658 x 1658`、控制台无错误。同期 HTTP 探针确认图片/直接文件读取为 `200`，缓存目录、编辑接口和普通工作区外文件仍为 `403`。
 - 前端消息渲染映射未改动；发布前仍应在安装候选上补一次“上传后发送消息 -> 缩略图 -> 点击预览”的完整交互确认。
 

--- a/tests.md
+++ b/tests.md
@@ -14585,7 +14585,7 @@ Verification:
 
 - 复现探针确认真实上传图片文件存在，但旧 7420 对 `/codex-local-image?path=...codex-web-uploads...` 返回 `HTTP 403` 与“该路径不在已登记的工作区目录内”。
 - `npm.cmd run verify:server-modules` 覆盖上传缓存图片读取、直接文件读取、文件卡片 browse 预览、缓存目录拒绝、编辑拒绝、外部路径拒绝和 junction 逃逸拒绝。
-- 上传缓存路径直接使用 Node `realpath` 完成规范化后再校验 canonical 根目录，不允许通过可替换的路径解析函数绕过静态分析；发布 PR 的高危 `js/path-injection` CodeQL 门禁必须为零。
+- 上传缓存路径只接受服务器生成的 `f-xxxxxx/<filename>` 两段结构；请求值只参与匹配，传入 `realpath` 的目录名和文件名必须来自实际目录枚举，且 canonical 根目录检查继续拒绝 junction/符号链接逃逸。发布 PR 的高危 `js/path-injection` CodeQL 门禁必须为零。
 - 隔离候选服务使用临时 Runtime DB 和无副作用 bridge；`agent-browser` 在 393 x 852 H5 视口打开真实上传路径，图片 `complete=true`、原始尺寸 `1658 x 1658`、控制台无错误。同期 HTTP 探针确认图片/直接文件读取为 `200`，缓存目录、编辑接口和普通工作区外文件仍为 `403`。
 - 前端消息渲染映射未改动；发布前仍应在安装候选上补一次“上传后发送消息 -> 缩略图 -> 点击预览”的完整交互确认。
 


### PR DESCRIPTION
## 问题

发布 PR #72 的 GitHub Advanced Security 门禁发现 1 个高危 `js/path-injection`：上传缓存读取把请求路径传给可替换的 `resolveRealPath` 函数变量，CodeQL 无法确认它是标准 canonicalization。

## 修复

- 移除 `resolveUploadedFilePath` 中不必要的 `realpath` 依赖注入
- 直接使用 Node `realpath`，保留 resolve 前的 upload-root 边界和 canonical 后的 junction 边界
- 保留合法上传、缺失文件、junction 逃逸和 HTTP 访问 smoke

## 验证

- `npm run verify:server-modules`
- `npm run build:cli`
- `npm run verify:governance`
- `npm run verify:release -- -AllowDirty -SchemaAudit skip`
- `git diff --check`

修复 PR 的 CodeQL 和 CI 全绿后再合并到 `beta`；随后重新核验发布 PR #72。