### PR TITLE
Windows 安装器：可选生成 CLI service shim

### DIFF
--- a/docs/windows-server.md
+++ b/docs/windows-server.md
@@ -64,6 +64,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\install-windows-server.ps1 `
   -Port 7420 `
   -Password "change-me" `
   -CreateStartupTask `
+  -CreateCliShim `
   -EnsureCodexLogin `
   -OpenFirewall `
   -InstallCloudflared `
@@ -75,6 +76,9 @@ The script writes:
 
 - a stable JSON config file at `%USERPROFILE%\.cx-codex\config.json`
 - a launcher at `%USERPROFILE%\.local\bin\cx-codex-start.cmd`
+- optionally, a CLI shim at `%USERPROFILE%\.local\bin\cx-codex.cmd` when `-CreateCliShim` is specified
+
+With the optional shim, the installed CLI service commands are available as `cx-codex service status`, `cx-codex service restart`, and the other commands shown by `cx-codex service --help`. The default installation does not create this command or install an npm global package.
 
 By default the installer writes `tunnel: false` and `open: false`, which is usually the right choice for Windows server usage.
 

--- a/docs/windows-server.md
+++ b/docs/windows-server.md
@@ -80,6 +80,8 @@ The script writes:
 
 With the optional shim, the installed CLI service commands are available as `cx-codex service status`, `cx-codex service restart`, and the other commands shown by `cx-codex service --help`. The default installation does not create this command or install an npm global package.
 
+Re-run with `-CreateCliShim` to refresh a shim owned by the same installation. Existing unmarked commands (including empty files) are preserved with a `CLI_SHIM_PRESERVED` warning. Uninstall removes only a shim with the CX-Codex ownership marker and the matching CLI target. If the command directory is not already on your `PATH`, invoke the `.cmd` file by its full path.
+
 By default the installer writes `tunnel: false` and `open: false`, which is usually the right choice for Windows server usage.
 
 ## 4. Health checks

--- a/release-capabilities.json
+++ b/release-capabilities.json
@@ -4,6 +4,7 @@
   "features": {
     "remoteQuick": true,
     "jsonOutput": true,
+    "cliShim": true,
     "stableJsonContract": true,
     "windowsUninstall": true
   }

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -14,6 +14,7 @@ param(
   [switch]$RemoteQuick,
   [switch]$JsonOutput,
   [switch]$SkipOpenPairing,
+  [switch]$CreateCliShim,
   [switch]$SkipStartupTask,
   [switch]$SkipWatchdogTask,
   [switch]$SkipFirewall,
@@ -748,6 +749,9 @@ function Assert-RepositoryCapabilities {
   if ($JsonOutput -and -not [bool]$manifest.features.jsonOutput) {
     throw "Selected CX-Codex source does not support JsonOutput."
   }
+  if ($CreateCliShim -and -not [bool]$manifest.features.cliShim) {
+    throw "Selected CX-Codex source does not support CreateCliShim."
+  }
 }
 
 function Get-VerifiedReleaseArchive {
@@ -914,6 +918,9 @@ $invokeArgs = @(
 )
 if (-not [string]::IsNullOrWhiteSpace($runtime.NpmCli)) {
   $invokeArgs += @("-NpmCliPath", $runtime.NpmCli)
+}
+if ($CreateCliShim) {
+  $invokeArgs += "-CreateCliShim"
 }
 
 if ($NoPassword) {

--- a/scripts/install-windows-server.ps1
+++ b/scripts/install-windows-server.ps1
@@ -10,6 +10,7 @@ param(
   [switch]$OpenBrowser,
   [string]$ConfigPath = "$env:USERPROFILE\.cx-codex\config.json",
   [string]$LauncherPath = "$env:USERPROFILE\.local\bin\cx-codex-start.cmd",
+  [switch]$CreateCliShim,
   [string]$NodeCommand = "",
   [string]$NpmCommand = "",
   [string]$NpmCliPath = "",
@@ -464,6 +465,27 @@ cd /d "$RepoRoot"
 "@
 
   Set-Content -LiteralPath $TargetLauncherPath -Value $launcherContent -Encoding ASCII
+}
+
+function Create-CliShimFile {
+  param(
+    [string]$TargetShimPath,
+    [string]$NodePath,
+    [string]$RepoRoot
+  )
+
+  $shimDir = Split-Path -Parent $TargetShimPath
+  if (-not [string]::IsNullOrWhiteSpace($shimDir)) {
+    New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
+  }
+
+  $shimContent = @"
+@echo off
+setlocal
+"$NodePath" "$RepoRoot\dist-cli\index.js" %*
+"@
+
+  Set-Content -LiteralPath $TargetShimPath -Value $shimContent -Encoding ASCII
 }
 
 function Create-ManagementShortcuts {
@@ -1086,6 +1108,10 @@ $configTempPath = "$ConfigPath.tmp-$PID"
 )
 Move-Item -LiteralPath $configTempPath -Destination $ConfigPath -Force
 Create-LauncherFile -TargetLauncherPath $LauncherPath -NodePath $nodeExecutable -RepoRoot $repoRoot -TargetConfigPath $ConfigPath
+$cliShimPath = Join-Path (Split-Path -Parent $LauncherPath) "cx-codex.cmd"
+if ($CreateCliShim) {
+  Create-CliShimFile -TargetShimPath $cliShimPath -NodePath $nodeExecutable -RepoRoot $repoRoot
+}
 $managementShortcutPaths = @(Create-ManagementShortcuts -TargetPort $Port)
 
 if ($CreateStartupTask) {
@@ -1198,6 +1224,9 @@ if (-not $JsonOutput) {
   Write-InstallerMessage "Install complete."
   Write-InstallerMessage "Config:   $ConfigPath"
   Write-InstallerMessage "Launcher: $LauncherPath"
+  if ($CreateCliShim) {
+    Write-InstallerMessage "CLI shim: $cliShimPath"
+  }
   foreach ($shortcutPath in $managementShortcutPaths) {
     Write-InstallerMessage "Manage:   $shortcutPath"
   }
@@ -1270,6 +1299,7 @@ if ($JsonOutput) {
       [ordered]@{ health = $false; auth = $false; websocketAuth = $false }
     }
     configPath = $ConfigPath
+    cliShimPath = if ($CreateCliShim) { $cliShimPath } else { "" }
     managementUrl = "http://127.0.0.1:$Port/local-setup"
     managementShortcuts = @($managementShortcutPaths)
     logsPath = $logDir

--- a/scripts/install-windows-server.ps1
+++ b/scripts/install-windows-server.ps1
@@ -479,13 +479,31 @@ function Create-CliShimFile {
     New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
   }
 
+  if (Test-Path -LiteralPath $TargetShimPath) {
+    $existingShimContent = Get-Content -LiteralPath $TargetShimPath -Raw -Encoding ASCII
+    $managedTarget = Join-Path $RepoRoot "dist-cli\index.js"
+    $normalizedExisting = $existingShimContent.Replace('/', '\')
+    $normalizedTarget = $managedTarget.Replace('/', '\')
+    $isManagedShim =
+      $normalizedExisting.Contains("rem CX-Codex managed CLI shim") -and
+      $normalizedExisting.IndexOf($normalizedTarget, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    if (-not $isManagedShim) {
+      Write-InstallerWarning `
+        -Code "CLI_SHIM_PRESERVED" `
+        -Message "Preserved existing CLI shim because it is not owned by this CX-Codex installation: $TargetShimPath"
+      return $false
+    }
+  }
+
   $shimContent = @"
 @echo off
+rem CX-Codex managed CLI shim
 setlocal
 "$NodePath" "$RepoRoot\dist-cli\index.js" %*
 "@
 
   Set-Content -LiteralPath $TargetShimPath -Value $shimContent -Encoding ASCII
+  return $true
 }
 
 function Create-ManagementShortcuts {
@@ -1110,7 +1128,7 @@ Move-Item -LiteralPath $configTempPath -Destination $ConfigPath -Force
 Create-LauncherFile -TargetLauncherPath $LauncherPath -NodePath $nodeExecutable -RepoRoot $repoRoot -TargetConfigPath $ConfigPath
 $cliShimPath = Join-Path (Split-Path -Parent $LauncherPath) "cx-codex.cmd"
 if ($CreateCliShim) {
-  Create-CliShimFile -TargetShimPath $cliShimPath -NodePath $nodeExecutable -RepoRoot $repoRoot
+  $cliShimCreated = Create-CliShimFile -TargetShimPath $cliShimPath -NodePath $nodeExecutable -RepoRoot $repoRoot
 }
 $managementShortcutPaths = @(Create-ManagementShortcuts -TargetPort $Port)
 
@@ -1224,7 +1242,7 @@ if (-not $JsonOutput) {
   Write-InstallerMessage "Install complete."
   Write-InstallerMessage "Config:   $ConfigPath"
   Write-InstallerMessage "Launcher: $LauncherPath"
-  if ($CreateCliShim) {
+  if ($CreateCliShim -and $cliShimCreated) {
     Write-InstallerMessage "CLI shim: $cliShimPath"
   }
   foreach ($shortcutPath in $managementShortcutPaths) {
@@ -1299,7 +1317,7 @@ if ($JsonOutput) {
       [ordered]@{ health = $false; auth = $false; websocketAuth = $false }
     }
     configPath = $ConfigPath
-    cliShimPath = if ($CreateCliShim) { $cliShimPath } else { "" }
+    cliShimPath = if ($CreateCliShim -and $cliShimCreated) { $cliShimPath } else { "" }
     managementUrl = "http://127.0.0.1:$Port/local-setup"
     managementShortcuts = @($managementShortcutPaths)
     logsPath = $logDir

--- a/scripts/install-windows-server.ps1
+++ b/scripts/install-windows-server.ps1
@@ -480,13 +480,13 @@ function Create-CliShimFile {
   }
 
   if (Test-Path -LiteralPath $TargetShimPath) {
-    $existingShimContent = Get-Content -LiteralPath $TargetShimPath -Raw -Encoding ASCII
+    $existingShimContent = [System.IO.File]::ReadAllText($TargetShimPath, [System.Text.Encoding]::ASCII)
     $managedTarget = Join-Path $RepoRoot "dist-cli\index.js"
     $normalizedExisting = $existingShimContent.Replace('/', '\')
     $normalizedTarget = $managedTarget.Replace('/', '\')
     $isManagedShim =
       $normalizedExisting.Contains("rem CX-Codex managed CLI shim") -and
-      $normalizedExisting.IndexOf($normalizedTarget, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+      $normalizedExisting.IndexOf(('"' + $normalizedTarget + '"'), [System.StringComparison]::OrdinalIgnoreCase) -ge 0
     if (-not $isManagedShim) {
       Write-InstallerWarning `
         -Code "CLI_SHIM_PRESERVED" `

--- a/scripts/install-windows-server.ps1
+++ b/scripts/install-windows-server.ps1
@@ -482,11 +482,17 @@ function Create-CliShimFile {
   if (Test-Path -LiteralPath $TargetShimPath) {
     $existingShimContent = [System.IO.File]::ReadAllText($TargetShimPath, [System.Text.Encoding]::ASCII)
     $managedTarget = Join-Path $RepoRoot "dist-cli\index.js"
-    $normalizedExisting = $existingShimContent.Replace('/', '\')
-    $normalizedTarget = $managedTarget.Replace('/', '\')
-    $isManagedShim =
-      $normalizedExisting.Contains("rem CX-Codex managed CLI shim") -and
-      $normalizedExisting.IndexOf(('"' + $normalizedTarget + '"'), [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    $targetMatch = [regex]::Match($existingShimContent, '(?m)^"[^"\r\n]+"\s+"(?<target>[^"\r\n]+)"\s+%\*')
+    $isManagedShim = $false
+    if ($existingShimContent.Contains("rem CX-Codex managed CLI shim") -and $targetMatch.Success) {
+      try {
+        $shimTarget = $targetMatch.Groups["target"].Value
+        $isManagedShim = [System.IO.Path]::IsPathRooted($shimTarget) -and
+          [string]::Equals([System.IO.Path]::GetFullPath($shimTarget), [System.IO.Path]::GetFullPath($managedTarget), [System.StringComparison]::OrdinalIgnoreCase)
+      } catch {
+        $isManagedShim = $false
+      }
+    }
     if (-not $isManagedShim) {
       Write-InstallerWarning `
         -Code "CLI_SHIM_PRESERVED" `

--- a/scripts/uninstall-windows.ps1
+++ b/scripts/uninstall-windows.ps1
@@ -236,6 +236,7 @@ $resolvedInstallDir = Assert-SafeManagedDirectory -Path $InstallDir -Label "inst
 $resolvedStateDir = Assert-SafeManagedDirectory -Path $StateDir -Label "state"
 $resolvedManagedBinDir = Assert-SafeManagedDirectory -Path $ManagedBinDir -Label "managed bin"
 $resolvedLauncherPath = Get-FullPath -Path $LauncherPath -Label "launcher"
+$resolvedCliShimPath = Join-Path $resolvedManagedBinDir "cx-codex.cmd"
 $resolvedConfigPath = Join-Path $resolvedStateDir "config.json"
 $resolvedTaskName = if ([string]::IsNullOrWhiteSpace($TaskName)) { "CodexUI-$Port" } else { $TaskName }
 $resolvedWatchdogTaskName = if ([string]::IsNullOrWhiteSpace($WatchdogTaskName)) { "CodexUI-$Port-Watchdog" } else { $WatchdogTaskName }
@@ -393,6 +394,16 @@ if ($firewallCommand) {
 $script:UninstallStage = "remove_program_files"
 Remove-ManagedItem -Path $resolvedServerPidPath -Label "server PID marker"
 Remove-ManagedItem -Path $resolvedLauncherPath -Label "launcher"
+if (Test-Path -LiteralPath $resolvedCliShimPath) {
+  $shimText = Get-Content -Raw -Encoding ASCII -LiteralPath $resolvedCliShimPath
+  $managedIndexPath = Join-Path $resolvedInstallDir "dist-cli\index.js"
+  if ($shimText -like "*$managedIndexPath*") {
+    Remove-ManagedItem -Path $resolvedCliShimPath -Label "CLI shim"
+  } else {
+    $script:PreservedItems.Add("cli-shim:$resolvedCliShimPath") | Out-Null
+    Write-UninstallWarning -Code "CLI_SHIM_PRESERVED" -Message "Preserved CLI shim because it does not target the managed CX-Codex installation."
+  }
+}
 foreach ($managementShortcutPath in $managementShortcutPaths) {
   if (
     (Test-Path -LiteralPath $managementShortcutPath) -and

--- a/scripts/uninstall-windows.ps1
+++ b/scripts/uninstall-windows.ps1
@@ -395,9 +395,14 @@ $script:UninstallStage = "remove_program_files"
 Remove-ManagedItem -Path $resolvedServerPidPath -Label "server PID marker"
 Remove-ManagedItem -Path $resolvedLauncherPath -Label "launcher"
 if (Test-Path -LiteralPath $resolvedCliShimPath) {
-  $shimText = Get-Content -Raw -Encoding ASCII -LiteralPath $resolvedCliShimPath
+  $shimText = [System.IO.File]::ReadAllText($resolvedCliShimPath, [System.Text.Encoding]::ASCII)
   $managedIndexPath = Join-Path $resolvedInstallDir "dist-cli\index.js"
-  if ($shimText -like "*$managedIndexPath*") {
+  $normalizedShim = $shimText.Replace('/', '\')
+  $normalizedTarget = $managedIndexPath.Replace('/', '\')
+  $isManagedShim =
+    $normalizedShim.Contains("rem CX-Codex managed CLI shim") -and
+    $normalizedShim.IndexOf(('"' + $normalizedTarget + '"'), [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+  if ($isManagedShim) {
     Remove-ManagedItem -Path $resolvedCliShimPath -Label "CLI shim"
   } else {
     $script:PreservedItems.Add("cli-shim:$resolvedCliShimPath") | Out-Null

--- a/scripts/uninstall-windows.ps1
+++ b/scripts/uninstall-windows.ps1
@@ -397,11 +397,17 @@ Remove-ManagedItem -Path $resolvedLauncherPath -Label "launcher"
 if (Test-Path -LiteralPath $resolvedCliShimPath) {
   $shimText = [System.IO.File]::ReadAllText($resolvedCliShimPath, [System.Text.Encoding]::ASCII)
   $managedIndexPath = Join-Path $resolvedInstallDir "dist-cli\index.js"
-  $normalizedShim = $shimText.Replace('/', '\')
-  $normalizedTarget = $managedIndexPath.Replace('/', '\')
-  $isManagedShim =
-    $normalizedShim.Contains("rem CX-Codex managed CLI shim") -and
-    $normalizedShim.IndexOf(('"' + $normalizedTarget + '"'), [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+  $targetMatch = [regex]::Match($shimText, '(?m)^"[^"\r\n]+"\s+"(?<target>[^"\r\n]+)"\s+%\*')
+  $isManagedShim = $false
+  if ($shimText.Contains("rem CX-Codex managed CLI shim") -and $targetMatch.Success) {
+    try {
+      $shimTarget = $targetMatch.Groups["target"].Value
+      $isManagedShim = [System.IO.Path]::IsPathRooted($shimTarget) -and
+        [string]::Equals([System.IO.Path]::GetFullPath($shimTarget), $managedIndexPath, [System.StringComparison]::OrdinalIgnoreCase)
+    } catch {
+      $isManagedShim = $false
+    }
+  }
   if ($isManagedShim) {
     Remove-ManagedItem -Path $resolvedCliShimPath -Label "CLI shim"
   } else {

--- a/scripts/verify-windows-productization.ps1
+++ b/scripts/verify-windows-productization.ps1
@@ -257,6 +257,7 @@ Start-Sleep -Seconds 16
     "-NodeCommand", $nodePath,
     "-SkipNpmInstall",
     "-SkipBuild",
+    "-CreateCliShim",
     "-JsonOutput"
   )
   if (Test-Path -LiteralPath $npmCliPath) {
@@ -283,6 +284,22 @@ URL=https://example.invalid/personal-shortcut
   Assert-True (-not [bool]$installJson.started) "No-start installation must report started=false."
   Assert-True (-not [bool]$installJson.healthReady) "No-start installation must report healthReady=false."
   Assert-True ([string]::IsNullOrWhiteSpace([string]$installJson.publicUrl)) "Local no-start installation must not report a public URL."
+  $cliShimPath = Join-Path $testRoot "bin\cx-codex.cmd"
+  $externalShimContent = "@echo off`r`nrem external command shim`r`n"
+  [System.IO.File]::WriteAllText($cliShimPath, $externalShimContent, [System.Text.Encoding]::ASCII)
+  $externalShimHash = (Get-FileHash -LiteralPath $cliShimPath -Algorithm SHA256).Hash
+  $externalShimResult = Invoke-CapturedPowerShell `
+    -ScriptPath $installScript `
+    -Arguments $installerArgs `
+    -CaptureRoot $testRoot `
+    -Label "install-external-shim"
+  Assert-True ($externalShimResult.ExitCode -eq 0) "Installer must succeed when preserving an external CLI shim."
+  $externalShimJson = ConvertFrom-SingleJsonLine -Text $externalShimResult.Stdout -Label "External shim installation"
+  Assert-True (@($externalShimJson.warnings | Where-Object { $_.code -eq "CLI_SHIM_PRESERVED" }).Count -eq 1) "Installer must warn when preserving an external CLI shim."
+  $preservedShimHash = (Get-FileHash -LiteralPath $cliShimPath -Algorithm SHA256).Hash
+  Assert-True ($preservedShimHash -ceq $externalShimHash) "Installer must not overwrite an external CLI shim."
+  $managedShimContent = "@echo off`r`nrem CX-Codex managed CLI shim`r`n`"$nodePath`" `"$(Join-Path $repoRoot 'dist-cli\index.js')`" %*`r`n"
+  Set-Content -LiteralPath $cliShimPath -Value $managedShimContent -Encoding ASCII
   $expectedManagementShortcuts = @(
     (Join-Path $env:CX_CODEX_MANAGEMENT_SHORTCUT_ROOT "Desktop\CX-Codex 管理中心 (17420).url"),
     (Join-Path $env:CX_CODEX_MANAGEMENT_SHORTCUT_ROOT "Programs\CX-Codex 管理中心.url")
@@ -331,6 +348,9 @@ URL=https://example.invalid/personal-shortcut
   Assert-True ([bool]$upgradedConfig.tunnel) "Upgrade must preserve the existing remote-access enabled state."
   Assert-True ($upgradedConfig.remoteAccessMode -eq "quick") "Upgrade must preserve the selected remote-access mode."
   Assert-True ($upgradedConfig.futureOption -eq "preserve-me") "Upgrade must preserve unknown future config fields."
+  $updatedShimContent = Get-Content -LiteralPath $cliShimPath -Raw -Encoding ASCII
+  Assert-True ($updatedShimContent -match "rem CX-Codex managed CLI shim") "Upgrade must retain the managed CLI shim marker."
+  Assert-True ($updatedShimContent.Contains((Join-Path $repoRoot "dist-cli\index.js"))) "Upgrade must update a managed CLI shim."
   $originalPassword = $null
   Write-Host "productization: stable install JSON passed"
 
@@ -360,8 +380,8 @@ URL=https://example.invalid/personal-shortcut
   }
   Assert-True (Test-Path -LiteralPath $shortcutConflictPath) "Uninstaller must preserve a shortcut it does not own."
   Assert-True `
-    (@($preserveJson.warnings).Count -eq 0) `
-    "Preserving a shortcut owned by another application must not emit an uninstall failure warning."
+    (@($preserveJson.warnings | Where-Object { $_.code -ne "CLI_SHIM_PRESERVED" }).Count -eq 0) `
+    "Preserving resources owned by another application must not emit an uninstall failure warning."
   Assert-True (Test-Path -LiteralPath (Join-Path $testRoot "state\config.json")) "User data must be preserved by default."
   Write-Host "productization: preserving uninstall passed"
 

--- a/scripts/verify-windows-productization.ps1
+++ b/scripts/verify-windows-productization.ps1
@@ -298,7 +298,18 @@ URL=https://example.invalid/personal-shortcut
   Assert-True (@($externalShimJson.warnings | Where-Object { $_.code -eq "CLI_SHIM_PRESERVED" }).Count -eq 1) "Installer must warn when preserving an external CLI shim."
   $preservedShimHash = (Get-FileHash -LiteralPath $cliShimPath -Algorithm SHA256).Hash
   Assert-True ($preservedShimHash -ceq $externalShimHash) "Installer must not overwrite an external CLI shim."
-  $managedShimContent = "@echo off`r`nrem CX-Codex managed CLI shim`r`n`"$nodePath`" `"$(Join-Path $repoRoot 'dist-cli\index.js')`" %*`r`n"
+  Assert-True ([string]::IsNullOrWhiteSpace([string]$externalShimJson.cliShimPath)) "A preserved external shim must not be reported as created."
+  [System.IO.File]::WriteAllText($cliShimPath, "", [System.Text.Encoding]::ASCII)
+  $emptyShimResult = Invoke-CapturedPowerShell `
+    -ScriptPath $installScript `
+    -Arguments $installerArgs `
+    -CaptureRoot $testRoot `
+    -Label "install-empty-shim"
+  Assert-True ($emptyShimResult.ExitCode -eq 0) "An empty existing CLI shim must not fail installation. $($emptyShimResult.Stderr)"
+  $emptyShimJson = ConvertFrom-SingleJsonLine -Text $emptyShimResult.Stdout -Label "Empty shim installation"
+  Assert-True (@($emptyShimJson.warnings | Where-Object { $_.code -eq "CLI_SHIM_PRESERVED" }).Count -eq 1) "An empty unowned shim must be preserved with a warning."
+  Assert-True ((Get-Item -LiteralPath $cliShimPath).Length -eq 0) "Installer must preserve the empty shim unchanged."
+  $managedShimContent = "@echo off`r`nrem CX-Codex managed CLI shim`r`nrem stale runtime`r`n`"C:\old-node\node.exe`" `"$(Join-Path $repoRoot 'dist-cli\index.js')`" %*`r`n"
   Set-Content -LiteralPath $cliShimPath -Value $managedShimContent -Encoding ASCII
   $expectedManagementShortcuts = @(
     (Join-Path $env:CX_CODEX_MANAGEMENT_SHORTCUT_ROOT "Desktop\CX-Codex 管理中心 (17420).url"),
@@ -332,6 +343,7 @@ URL=https://example.invalid/personal-shortcut
     "-NodeCommand", $nodePath,
     "-SkipNpmInstall",
     "-SkipBuild",
+    "-CreateCliShim",
     "-JsonOutput"
   )
   if (Test-Path -LiteralPath $npmCliPath) {
@@ -351,12 +363,16 @@ URL=https://example.invalid/personal-shortcut
   $updatedShimContent = Get-Content -LiteralPath $cliShimPath -Raw -Encoding ASCII
   Assert-True ($updatedShimContent -match "rem CX-Codex managed CLI shim") "Upgrade must retain the managed CLI shim marker."
   Assert-True ($updatedShimContent.Contains((Join-Path $repoRoot "dist-cli\index.js"))) "Upgrade must update a managed CLI shim."
+  Assert-True ($updatedShimContent.Contains($nodePath) -and $updatedShimContent -notmatch 'stale runtime|old-node') "Upgrade must replace the old Node command, not merely leave the old shim in place."
   $originalPassword = $null
   Write-Host "productization: stable install JSON passed"
 
   $fakeInstallDir = Join-Path $testRoot "program"
   New-Item -ItemType Directory -Path $fakeInstallDir -Force | Out-Null
   Set-Content -LiteralPath (Join-Path $fakeInstallDir "marker.txt") -Value "managed program"
+  $externalUninstallShim = "@echo off`r`nrem external wrapper for `"$(Join-Path $fakeInstallDir 'dist-cli\index.js')`"`r`n"
+  [System.IO.File]::WriteAllText($cliShimPath, $externalUninstallShim, [System.Text.Encoding]::ASCII)
+  $externalUninstallHash = (Get-FileHash -LiteralPath $cliShimPath -Algorithm SHA256).Hash
 
   $preserveResult = Invoke-CapturedPowerShell `
     -ScriptPath $uninstallScript `
@@ -379,19 +395,24 @@ URL=https://example.invalid/personal-shortcut
     Assert-True (-not (Test-Path -LiteralPath $managementShortcut)) "Uninstaller must remove management shortcut: $managementShortcut"
   }
   Assert-True (Test-Path -LiteralPath $shortcutConflictPath) "Uninstaller must preserve a shortcut it does not own."
+  Assert-True (Test-Path -LiteralPath $cliShimPath) "Uninstaller must preserve an unmarked external wrapper even when it mentions the managed target."
+  Assert-True ((Get-FileHash -LiteralPath $cliShimPath -Algorithm SHA256).Hash -ceq $externalUninstallHash) "Uninstaller must not change the external wrapper."
+  Assert-True (@($preserveJson.warnings | Where-Object { $_.code -eq "CLI_SHIM_PRESERVED" }).Count -eq 1) "Uninstall must report that the external shim was preserved."
   Assert-True `
     (@($preserveJson.warnings | Where-Object { $_.code -ne "CLI_SHIM_PRESERVED" }).Count -eq 0) `
     "Preserving resources owned by another application must not emit an uninstall failure warning."
   Assert-True (Test-Path -LiteralPath (Join-Path $testRoot "state\config.json")) "User data must be preserved by default."
   Write-Host "productization: preserving uninstall passed"
 
-  $secondInstallDir = Join-Path $testRoot "program-remove-data"
+  $secondInstallDir = Join-Path $testRoot "program-remove-data[managed]"
   $secondStateDir = Join-Path $testRoot "state-remove-data"
   $managedBinDir = Join-Path $testRoot "managed-bin"
   $managedCloudflaredPath = Join-Path $managedBinDir "cloudflared-0123456789ab.exe"
   New-Item -ItemType Directory -Path $secondInstallDir,$secondStateDir,$managedBinDir -Force | Out-Null
   Set-Content -LiteralPath (Join-Path $secondInstallDir "marker.txt") -Value "managed program"
   Set-Content -LiteralPath $managedCloudflaredPath -Value "managed cloudflared"
+  $secondShimPath = Join-Path $managedBinDir "cx-codex.cmd"
+  Set-Content -LiteralPath $secondShimPath -Encoding ASCII -Value "@echo off`r`nrem CX-Codex managed CLI shim`r`n`"$nodePath`" `"$(Join-Path $secondInstallDir 'dist-cli\index.js')`" %*"
   [ordered]@{
     port = 17421
     cloudflaredCommand = $managedCloudflaredPath
@@ -417,6 +438,7 @@ URL=https://example.invalid/personal-shortcut
   Assert-True (-not (Test-Path -LiteralPath $secondInstallDir)) "Full uninstall must remove the managed program directory."
   Assert-True (-not (Test-Path -LiteralPath $secondStateDir)) "Full uninstall must remove CX-Codex user data when requested."
   Assert-True (-not (Test-Path -LiteralPath $managedCloudflaredPath)) "Full uninstall must remove the managed cloudflared binary when requested."
+  Assert-True (-not (Test-Path -LiteralPath $secondShimPath)) "Full uninstall must remove its marked CLI shim even when the install path contains brackets."
   Write-Host "productization: full uninstall passed"
 
   $uninstallFailureResult = Invoke-CapturedPowerShell `

--- a/scripts/verify-windows-productization.ps1
+++ b/scripts/verify-windows-productization.ps1
@@ -412,7 +412,9 @@ URL=https://example.invalid/personal-shortcut
   Set-Content -LiteralPath (Join-Path $secondInstallDir "marker.txt") -Value "managed program"
   Set-Content -LiteralPath $managedCloudflaredPath -Value "managed cloudflared"
   $secondShimPath = Join-Path $managedBinDir "cx-codex.cmd"
-  Set-Content -LiteralPath $secondShimPath -Encoding ASCII -Value "@echo off`r`nrem CX-Codex managed CLI shim`r`n`"$nodePath`" `"$(Join-Path $secondInstallDir 'dist-cli\index.js')`" %*"
+  $shortTestRoot = (New-Object -ComObject Scripting.FileSystemObject).GetFolder($testRoot).ShortPath
+  $shortShimTarget = Join-Path $shortTestRoot "program-remove-data[managed]\dist-cli\index.js"
+  Set-Content -LiteralPath $secondShimPath -Encoding ASCII -Value "@echo off`r`nrem CX-Codex managed CLI shim`r`n`"$nodePath`" `"$shortShimTarget`" %*"
   [ordered]@{
     port = 17421
     cloudflaredCommand = $managedCloudflaredPath
@@ -438,7 +440,7 @@ URL=https://example.invalid/personal-shortcut
   Assert-True (-not (Test-Path -LiteralPath $secondInstallDir)) "Full uninstall must remove the managed program directory."
   Assert-True (-not (Test-Path -LiteralPath $secondStateDir)) "Full uninstall must remove CX-Codex user data when requested."
   Assert-True (-not (Test-Path -LiteralPath $managedCloudflaredPath)) "Full uninstall must remove the managed cloudflared binary when requested."
-  Assert-True (-not (Test-Path -LiteralPath $secondShimPath)) "Full uninstall must remove its marked CLI shim even when the install path contains brackets."
+  Assert-True (-not (Test-Path -LiteralPath $secondShimPath)) "Full uninstall must remove its marked CLI shim with short paths and brackets. $($removeDataResult.Stderr)"
   Write-Host "productization: full uninstall passed"
 
   $uninstallFailureResult = Invoke-CapturedPowerShell `

--- a/tests.md
+++ b/tests.md
@@ -1,5 +1,13 @@
 # Tests
 
+## Optional Windows CLI shim (2026-09-08)
+
+- `-CreateCliShim` creates a user-local command only when requested. Repeating the option updates the Node command in a shim owned by the same installation.
+- Installation preserves foreign and empty same-name files, reports `CLI_SHIM_PRESERVED`, and leaves `cliShimPath` empty when no shim was created.
+- Uninstall requires both the ownership marker and quoted CLI target. A foreign wrapper that mentions the target stays unchanged; a managed target containing square brackets is removed using literal path matching.
+- Verify with `npm run verify:windows-productization`: hash checks for preserved files, a stale Node command replaced during upgrade, and both uninstall ownership cases. This is isolated Windows script evidence, not a production service or Android test.
+- Rollback: revert the CLI shim PR; the option is off by default and no global npm installation or PATH mutation is performed.
+
 ## 正式标签前的签名候选制品（2026-08-29）
 
 ### Expected behavior


### PR DESCRIPTION
Windows bootstrap and installer gain the optional `-CreateCliShim` switch. It creates `cx-codex.cmd` next to the launcher, allowing the managed Release CLI to handle commands such as `cx-codex service status` without an npm global install.

Installation and uninstall both require the CX-Codex ownership marker and the quoted target path before replacing or deleting an existing shim. Foreign commands and empty files remain unchanged with a `CLI_SHIM_PRESERVED` warning. Repeating the option refreshes the Node command in a managed shim; default installation behavior stays unchanged.

Validation: frontend and CLI builds passed; isolated Windows productization smoke passed, including foreign/empty file preservation, an actual stale Node command upgrade, foreign wrappers mentioning the target, literal bracket-containing paths, install/uninstall JSON, startup health and process-tree cleanup. The empty-file case failed on the prior revision with InvokeMethodOnNull and passes with the fix.

Target beta for candidate verification, followed by a verified beta-to-main PR. No version tag, package publication or production deployment is included.
