### PR TITLE
ci: combine main dependency security bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2341,10 +2341,11 @@
       "license": "MIT"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmmirror.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4492,9 +4492,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
This combines the two main-target dependency security updates that are blocked when checked independently:

- #85: @xmldom/xmldom 0.8.13 -> 0.8.15
- #86: qs 6.15.3 -> 6.16.0

Reason:
- Each original PR leaves one remaining moderate audit finding, so its individual build check fails.
- The combined candidate resolves the audit set together.

Local verification on Windows, isolated worktree from origin/main:
- npm 10.9.8 via temporary npm tarball
- npm ci: 0 vulnerabilities
- npm run verify:dependency-security: passed, 0 vulnerabilities across 437 dependencies
- npm run build:frontend: passed